### PR TITLE
Fix text alignment and truncation issue in quota legend

### DIFF
--- a/components/PredictedCollegeTables.js
+++ b/components/PredictedCollegeTables.js
@@ -3,62 +3,53 @@ import PropTypes from "prop-types";
 import examConfigs from "../examConfig";
 
 const PredictedCollegesTable = ({ data = [], exam = "" }) => {
-  const commonTableClass =
-    "w-full mx-auto border-collapse text-sm sm:text-base";
-  const commonHeaderClass =
-    "bg-gray-200 font-bold text-center text-xs sm:text-sm md:text-base";
-  const commonCellClass =
-    "p-2 border border-gray-300 text-center text-xs sm:text-sm md:text-base";
+  const tableClasses = "w-full border-collapse text-sm sm:text-base";
+  const headerClasses = "bg-gray-200 font-bold text-center p-2 text-xs sm:text-sm md:text-base";
+  const cellClasses = "p-2 border border-gray-300 text-center text-xs sm:text-sm md:text-base";
 
-  const examConfig = examConfigs[exam];
+  const examConfig = examConfigs?.[exam];
 
-  const renderTableHeader = () => {
-    const predicted_colleges_table_column = [
-      { key: "state", label: "State" },
-      { key: "institute", label: "Institute" },
-      { key: "academic_program_name", label: "Academic Program Name" },
-      { key: "closing_rank", label: "Closing Rank" },
-      { key: "quota", label: "Quota" },
-    ];
+  const tableHeaders = [
+    { key: "state", label: "State" },
+    { key: "institute", label: "Institute" },
+    { key: "academic_program_name", label: "Academic Program Name" },
+    { key: "closing_rank", label: "Closing Rank" },
+    { key: "quota", label: "Quota" },
+  ];
 
-    return (
-      <tr className={commonHeaderClass}>
-        {predicted_colleges_table_column.map((column) => (
-          <th key={column.key} className="p-2 border-r border-gray-300">
-            {column.label}
-          </th>
-        ))}
-      </tr>
-    );
-  };
+  const renderTableHeader = () => (
+    <tr className={headerClasses}>
+      {tableHeaders.map(({ key, label }) => (
+        <th key={key} className="p-2 border-r border-gray-300">
+          {label}
+        </th>
+      ))}
+    </tr>
+  );
 
-  const renderTableBody = () => {
-    return data.map((item, index) => (
+  const renderTableBody = () => (
+    data.map((item, index) => (
       <tr
         key={index}
-        className={`${commonCellClass} ${
-          index % 2 === 0 ? "bg-gray-100" : "bg-white"
-        }`}
+        className={`${cellClasses} ${index % 2 === 0 ? "bg-gray-100" : "bg-white"}`}
       >
-        <td className="p-2 border-r border-gray-300">{item["State"]}</td>
-        <td className="p-2 border-r border-gray-300">{item["Institute"]}</td>
-        <td className="p-2 border-r border-gray-300">
-          {item["Academic Program Name"]}
-        </td>
-        <td className="p-2 border-r border-gray-300">{item["Closing Rank"]}</td>
-        <td className="p-2">{item["Quota"]}</td>
+        <td className="p-2 border-r border-gray-300">{item?.State}</td>
+        <td className="p-2 border-r border-gray-300">{item?.Institute}</td>
+        <td className="p-2 border-r border-gray-300">{item?.["Academic Program Name"]}</td>
+        <td className="p-2 border-r border-gray-300">{item?.["Closing Rank"]}</td>
+        <td className="p-2">{item?.Quota}</td>
       </tr>
-    ));
-  };
+    ))
+  );
 
   const renderLegend = () => {
-    if (!examConfig || !examConfig.legend) return null;
+    if (!examConfig?.legend) return null;
 
     return (
-      <div className="flex flex-col items-center text-sm sm:text-base mb-4">
-        {examConfig.legend.map((item, index) => (
+      <div className="w-full text-center mb-4">
+        {examConfig.legend.map(({ key, value }, index) => (
           <p key={index} className="leading-4 mb-1">
-            {item.key}: {item.value}
+            {key}: {value}
           </p>
         ))}
       </div>
@@ -70,12 +61,14 @@ const PredictedCollegesTable = ({ data = [], exam = "" }) => {
   }
 
   return (
-    <div className="w-full mx-auto overflow-x-auto">
+    <div className="w-full">
       {renderLegend()}
-      <table className={`${commonTableClass} border border-gray-300`}>
-        <thead>{renderTableHeader()}</thead>
-        <tbody>{renderTableBody()}</tbody>
-      </table>
+      <div className="overflow-x-auto">
+        <table className={`${tableClasses} border border-gray-300`}>
+          <thead>{renderTableHeader()}</thead>
+          <tbody>{renderTableBody()}</tbody>
+        </table>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
Fixes #36

On mobile devices or screens with smaller resolutions, both the table content and the legend (e.g., AI: All India, HS: Home State, OS: Out of State) were getting truncated or improperly displayed. This means users could not see the full information, which is critical for understanding the data.
Problem: The table content was getting cut off or truncated on smaller screens (e.g., mobile devices).
Solution: We wrapped the table inside a div container with the class overflow-x-auto, which allows the table to be horizontally scrollable when it exceeds the width of the screen. This ensures no content is hidden or truncated, and the user can scroll to see all columns.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/avantifellows/college-predictor/issues/36?shareId=207c5cd0-f0e4-41b0-8d12-7275860055ae).