### PR TITLE
Security: Fix Path Traversal and Prototype Pollution in exam-result API

### DIFF
--- a/pages/api/exam-result.js
+++ b/pages/api/exam-result.js
@@ -46,7 +46,7 @@ export default async function handler(req, res) {
 
   const { exam, rank } = req.query;
 
-  if (!exam || !examConfigs[exam]) {
+  if (!exam || !Object.prototype.hasOwnProperty.call(examConfigs, exam)) {
     return res.status(400).json({ error: "Invalid or missing exam parameter" });
   }
 
@@ -65,9 +65,17 @@ export default async function handler(req, res) {
   }
 
   try {
-    const dataPath = config.getDataPath(req.query.category);
+    const categoryStr = req.query.category || "";
+    // Sanitize category to prevent path traversal
+    const category = require("path").basename(categoryStr);
+
+    const dataPath = config.getDataPath(category);
     const data = await fs.readFile(dataPath, "utf8");
     const fullData = JSON.parse(data);
+
+    if (!Array.isArray(fullData)) {
+      throw new Error("Invalid data format: expected an array of results");
+    }
 
     // Get filters based on the exam config and query parameters
     const filters = config.getFilters(req.query);
@@ -224,7 +232,7 @@ export default async function handler(req, res) {
     console.error("Error reading file:", error);
     res.status(500).json({
       error: "Unable to retrieve data",
-      details: error.message,
+      details: error.code === "ENOENT" ? "Data not found" : error.message,
     });
   }
 }


### PR DESCRIPTION
## Description
This PR addresses two critical security vulnerabilities in the `/api/exam-result` endpoint:
1. **Prototype Pollution**: Prevented accessing `__proto__` to crash the server when checking `examConfigs[exam]`.
2. **Directory/Path Traversal**: Added `path.basename` sanitation to the `category` parameter so users cannot pass `../../../` to read arbitrary `.json` files on the server (e.g. `package.json`).
3. Added checks to verify the parsed JSON is actually an array, preventing `TypeError` server crashes.
4. Suppressed raw filesystem error messages (like `ENOENT`) from being sent to the client to prevent path disclosures.

## Before Fix

Prototype Pollution: Returns a 500 error crashing the app (`TypeError: config.fields is not iterable`).

Path Traversal: If combined with full required parameters, arbitrary valid JSON files like `package.json` are loaded into memory and cause an unhandled crash when array methods like `.filter` are called on the object.
```json
HTTP/1.1 500 Internal Server Error
{"error":"Unable to retrieve data","details":"filteredData.filter is not a function"}
```

## After Fix

**Prototype Pollution (`exam=__proto__`):**
Correctly identifies as an invalid exam and returns a 400 Bad Request.
```json
HTTP/1.1 400 Bad Request
{"error":"Invalid or missing exam parameter"}
```

**Path Traversal (`category=../../../package`):**
Sanitizes `../../../package` to simply `package`. File isn't found in the expected directory, returning a clean error without revealing absolute file paths.
```json
HTTP/1.1 500 Internal Server Error
{"error":"Unable to retrieve data","details":"Data not found"}
```