### PR TITLE
fix: add pagination to scholarship page and use API endpoint

### DIFF
--- a/components/ScholarshipReferenceBrowser.js
+++ b/components/ScholarshipReferenceBrowser.js
@@ -30,16 +30,19 @@ const isReferenceClosed = (scholarship) => {
   return deadline < now;
 };
 
+const PAGE_SIZE = 20;
+
 const ScholarshipReferenceBrowser = () => {
   const [scholarships, setScholarships] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
   const [expandedRows, setExpandedRows] = useState({});
+  const [currentPage, setCurrentPage] = useState(1);
 
   useEffect(() => {
     const loadScholarships = async () => {
       try {
-        const response = await fetch("/data/scholarships/scholarship_data.json");
+        const response = await fetch("/api/scholarship-data");
         const data = await response.json();
         const sortedData = [...data].sort((a, b) =>
           String(a["Scholarship Name"] || "").localeCompare(
@@ -63,11 +66,18 @@ const ScholarshipReferenceBrowser = () => {
   );
 
   const filteredScholarships = useMemo(() => {
+    setCurrentPage(1);
     if (!searchTerm.trim()) {
       return scholarships;
     }
     return fuseInstance.search(searchTerm.trim()).map((result) => result.item);
   }, [fuseInstance, scholarships, searchTerm]);
+
+  const totalPages = Math.ceil(filteredScholarships.length / PAGE_SIZE);
+  const paginatedScholarships = filteredScholarships.slice(
+    (currentPage - 1) * PAGE_SIZE,
+    currentPage * PAGE_SIZE
+  );
 
   const closedCount = useMemo(
     () => scholarships.filter((item) => isReferenceClosed(item)).length,
@@ -128,11 +138,46 @@ const ScholarshipReferenceBrowser = () => {
             Loading scholarship reference list...
           </div>
         ) : filteredScholarships.length > 0 ? (
-          <ScholarshipTable
-            filteredData={filteredScholarships}
-            toggleRowExpansion={toggleRowExpansion}
-            expandedRows={expandedRows}
-          />
+          <>
+            <ScholarshipTable
+              filteredData={paginatedScholarships}
+              toggleRowExpansion={toggleRowExpansion}
+              expandedRows={expandedRows}
+            />
+            {totalPages > 1 && (
+              <div className="flex items-center justify-between mt-4 px-1">
+                <p className="text-sm text-[#5b3a34]">
+                  Showing{" "}
+                  <span className="font-semibold">
+                    {(currentPage - 1) * PAGE_SIZE + 1}–
+                    {Math.min(currentPage * PAGE_SIZE, filteredScholarships.length)}
+                  </span>{" "}
+                  of{" "}
+                  <span className="font-semibold">{filteredScholarships.length}</span>{" "}
+                  scholarships
+                </p>
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setCurrentPage((p) => Math.max(1, p - 1))}
+                    disabled={currentPage <= 1}
+                    className="px-4 py-2 text-sm rounded-md border border-[#d8c7c1] bg-white hover:bg-[#f8efec] disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    ← Prev
+                  </button>
+                  <span className="px-3 py-2 text-sm text-[#5b3a34]">
+                    Page {currentPage} of {totalPages}
+                  </span>
+                  <button
+                    onClick={() => setCurrentPage((p) => Math.min(totalPages, p + 1))}
+                    disabled={currentPage >= totalPages}
+                    className="px-4 py-2 text-sm rounded-md border border-[#d8c7c1] bg-white hover:bg-[#f8efec] disabled:opacity-40 disabled:cursor-not-allowed"
+                  >
+                    Next →
+                  </button>
+                </div>
+              </div>
+            )}
+          </>
         ) : (
           <div className="rounded-2xl border border-[#eaded8] bg-white px-6 py-12 text-center text-[#5b3a34] shadow-sm">
             No scholarships matched your search. Try a broader keyword.


### PR DESCRIPTION
Closes #148 

## Problem
The `/scholarships` page rendered all 192 scholarship entries at once with no 
pagination, causing a very long page and poor UX on low-end devices.

Additionally, `ScholarshipReferenceBrowser.js` was fetching scholarship data 
directly from the static JSON file (`/data/scholarships/scholarship_data.json`) 
instead of the existing `/api/scholarship-data` endpoint  - bypassing the API layer.

## Changes Made

### 1. Pagination (`ScholarshipReferenceBrowser.js`)
- Added client-side pagination showing 20 scholarships per page
- Added Prev/Next navigation buttons at the bottom
- Shows "Showing 1-20 of 192 scholarships" count for clarity
- Page automatically resets to 1 when the search term changes

### 2. API Consistency (`ScholarshipReferenceBrowser.js`)
- Replaced `fetch("/data/scholarships/scholarship_data.json")` 
  with `fetch("/api/scholarship-data")`
- Makes the component consistent with the rest of the app
- Future-proofs the component for the planned Postgres migration (DMP 2026 goal)

## Files Changed
- `components/ScholarshipReferenceBrowser.js`

## Screenshots
<img width="1220" height="87" alt="Screenshot 2026-04-24 at 1 58 55 PM" src="https://github.com/user-attachments/assets/94e50ab9-a2f0-4875-98e7-4373540d0664" />
