### PR TITLE
classify college prediction table

### DIFF
--- a/components/CollegeCategoryBadge.js
+++ b/components/CollegeCategoryBadge.js
@@ -1,0 +1,23 @@
+import PropTypes from "prop-types";
+
+const styles = {
+  Safe:     "bg-green-100 text-green-800 border border-green-300",
+  Moderate: "bg-yellow-100 text-yellow-800 border border-yellow-300",
+  Dream:    "bg-red-100 text-red-800 border border-red-300",
+  Unknown:  "bg-gray-100 text-gray-500 border border-gray-200",
+};
+
+const CollegeCategoryBadge = ({ category }) => {
+  const cls = styles[category] ?? styles.Unknown;
+  return (
+    <span className={`inline-block px-2 py-0.5 rounded-full text-xs font-semibold ${cls}`}>
+      {category ?? "Unknown"}
+    </span>
+  );
+};
+
+CollegeCategoryBadge.propTypes = {
+  category: PropTypes.oneOf(["Safe", "Moderate", "Dream", "Unknown"]),
+};
+
+export default CollegeCategoryBadge;

--- a/components/PredictedCollegeTables.js
+++ b/components/PredictedCollegeTables.js
@@ -2,6 +2,7 @@ import React, { useEffect, useMemo, useState } from "react";
 import { ArrowDown, ArrowUp, ArrowUpDown, Info } from "lucide-react";
 import PropTypes from "prop-types";
 import examConfigs from "../examConfig";
+import CollegeCategoryBadge from "./CollegeCategoryBadge";
 
 // Define fields for the expanded view
 const expandedFields = {
@@ -194,6 +195,9 @@ const PredictedCollegesTable = ({
   exam = "",
   searchTerm = "",
   onSearchChange = null,
+  activeCategory = "All",
+  onCategoryChange = null,
+
 }) => {
   const [expandedRows, setExpandedRows] = useState({});
   const [showAllRows, setShowAllRows] = useState(false); // State for showing all rows
@@ -538,6 +542,11 @@ const PredictedCollegesTable = ({
     return copy;
   }, [data, sortConfig, supportsSalarySort]);
 
+  const categoryFilteredData =
+    activeCategory === "All"
+      ? sortedData
+      : sortedData.filter((item) => item.admissionCategory === activeCategory);
+
   const getDisplayValue = (column, transformedItem) => {
     const rawValue = transformedItem[column.key];
     if (column.format) {
@@ -653,14 +662,17 @@ const PredictedCollegesTable = ({
           )}
         </th>
       ))}
+      <th className="px-4 py-3 border-b border-[#decac3] whitespace-nowrap">
+        Chance
+      </th>
       {supportsExpandedView && <th className="p-2">Actions</th>}
     </tr>
   );
 
   const renderTableBody = () => {
     const rowsToRender = showAllRows
-      ? sortedData
-      : sortedData.slice(0, ROWS_PER_PAGE_INITIAL);
+      ? categoryFilteredData
+      : categoryFilteredData.slice(0, ROWS_PER_PAGE_INITIAL);
 
     return rowsToRender.map((item, index) => {
       const transformedItem = transformData(item);
@@ -677,6 +689,9 @@ const PredictedCollegesTable = ({
                 {getDisplayValue(column, transformedItem)}
               </td>
             ))}
+            <td className="px-4 py-3 align-top">
+              <CollegeCategoryBadge category={item.admissionCategory} />
+            </td>
             {supportsExpandedView && (
               <td className="px-4 py-3">
                 <div className="flex justify-center">
@@ -767,8 +782,26 @@ const PredictedCollegesTable = ({
             )}
           </div>
           <div className="flex flex-col gap-3 sm:flex-row sm:items-center lg:justify-end">
+            <div className="flex gap-2 flex-wrap">
+              {["All", "Safe", "Moderate", "Dream"].map((cat) => (
+                <button
+                  key={cat}
+                  onClick={() => {
+                    onCategoryChange?.(cat);
+                    setShowAllRows(false);
+                  }}
+                  className={`px-3 py-1 rounded-full text-xs font-semibold border transition-colors
+                    ${activeCategory === cat
+                      ? "bg-[#5b3a34] text-white border-[#5b3a34]"
+                      : "bg-white text-[#5b3a34] border-[#5b3a34] hover:bg-[#f5ece9]"
+                    }`}
+                >
+                  {cat}
+                </button>
+              ))}
+            </div>
             <p className="text-sm text-[#5b3a34]">
-              Showing {sortedData.length.toLocaleString("en-IN")} matching
+              Showing {categoryFilteredData.length.toLocaleString("en-IN")} matching
               options.
             </p>
             <button
@@ -786,7 +819,7 @@ const PredictedCollegesTable = ({
           <tbody>{renderTableBody()}</tbody>
         </table>
       </div>
-      {data.length > ROWS_PER_PAGE_INITIAL &&
+      {categoryFilteredData.length > ROWS_PER_PAGE_INITIAL &&
         !showAllRows && ( // Conditional button rendering
           <div className="flex justify-center mt-4">
             <button
@@ -827,6 +860,8 @@ PredictedCollegesTable.propTypes = {
   exam: PropTypes.string.isRequired,
   searchTerm: PropTypes.string,
   onSearchChange: PropTypes.func,
+  activeCategory: PropTypes.string,
+  onCategoryChange: PropTypes.func,
 };
 
 export default PredictedCollegesTable;

--- a/pages/api/exam-result.js
+++ b/pages/api/exam-result.js
@@ -1,6 +1,7 @@
 import fs from "fs/promises";
 import examConfigs from "../../examConfig";
 import rateLimit from "express-rate-limit";
+import { classifyCollege } from "../../utils/ClassifyCollege";
 
 // Helper function to get client IP address
 const getIp = (req) => {
@@ -259,7 +260,33 @@ export default async function handler(req, res) {
       });
     }
 
-    return res.status(200).json(filteredData);
+    const getStudentRank = () => {
+      if (exam === "JEE Advanced") return parseFloat(req.query.advRank) || null;
+      if (exam === "JEE Main" || exam === "JoSAA") return parseFloat(req.query.mainRank) || null;
+      if (exam === "GUJCET") return null; // marks-based, not rank — skip classification
+      if (exam === "TNEA") return null;   // marks-based, not rank — skip classification
+      return parseFloat(req.query.rank) || null;
+    };
+
+    const studentRank = getStudentRank();
+
+    const classifiedData = filteredData.map((item) => {
+      const rawClosingRank =
+        item["Closing Rank"] ?? // JEE Main, JEE Advanced, JoSAA, NEET, KCET, MHT CET
+        item["closing_rank"] ?? // TGEAPCET
+        null;
+
+      return {
+        ...item,
+        admissionCategory: classifyCollege(
+          studentRank,
+          parseFloat(rawClosingRank) || null
+        ),
+      };
+    });
+
+    return res.status(200).json(classifiedData);
+
   } catch (error) {
     console.error("Error reading file:", error);
     res.status(500).json({

--- a/pages/college_predictor.js
+++ b/pages/college_predictor.js
@@ -116,6 +116,7 @@ const CollegePredictor = () => {
   const [currentExam, setCurrentExam] = useState(null);
   const [showSelectionDetails, setShowSelectionDetails] = useState(false);
   const [primaryInputError, setPrimaryInputError] = useState("");
+  const [activeCategory, setActiveCategory] = useState("All");
 
   useEffect(() => {
     // Initialize queryObject from router.query
@@ -222,6 +223,7 @@ const CollegePredictor = () => {
         const data = await response.json();
         setFullData(data);
         setFilteredData(data);
+        setActiveCategory("All");
         setError(null);
       }
     } catch (error) {
@@ -1083,6 +1085,8 @@ const CollegePredictor = () => {
                 exam={queryObject.exam}
                 searchTerm={searchTerm}
                 onSearchChange={handleSearchChange}
+                activeCategory={activeCategory}
+                onCategoryChange={setActiveCategory}
               />
             </>
           ) : (

--- a/utils/ClassifyCollege.js
+++ b/utils/ClassifyCollege.js
@@ -1,0 +1,14 @@
+export function classifyCollege(studentRank,closingRank){
+    if(!studentRank ||
+    !closingRank ||
+    isNaN(studentRank) ||
+    isNaN(closingRank) ||
+    closingRank <= 0){
+        return "Unknown";
+    }
+
+    const ratio= studentRank/closingRank;
+    if(ratio<=0.85) return "Safe";
+    if(ratio<=1.05) return "Moderate";
+    return "Dream";
+}


### PR DESCRIPTION
fixes #145 

**Problem**
Searching with a broad query (e.g. JoSAA rank 14,000, OPEN, Female-only) 
returns 500+ results with no way to prioritise them. Students cannot tell 
which colleges are realistic vs out of reach.

**Solution**
Classifies each result as Safe / Moderate / Dream based on the ratio of 
the student's rank to the college's historical closing rank:

- Safe :ratio ≤ 0.85  (rank comfortably within cutoff)
- Moderate : ratio 0.85–1.05  (rank close to cutoff)  
- Dream : ratio > 1.05  (rank beyond cutoff)

 **Notes**
- Marks-based exams (GUJCET, TNEA) show "Unknown" badge since marks 
  and ranks cannot be compared with the same ratio.
- Thresholds (0.85 / 1.05) are a starting point and easy to adjust.
- No dependency changes, no pagination, no unrelated refactors.

<img width="1801" height="963" alt="Screenshot from 2026-04-25 00-11-31" src="https://github.com/user-attachments/assets/ed2b0367-a76b-4c65-8c0a-0804459a95cd" />



<img width="1801" height="963" alt="Screenshot from 2026-04-25 00-11-07" src="https://github.com/user-attachments/assets/bd06e8a8-b440-4a6a-9cff-ec2727779629" />
