### PR TITLE
Feat: Add filter to show only open scholarships in ScholarshipReferenceBrowser

### DIFF
--- a/components/ScholarshipReferenceBrowser.js
+++ b/components/ScholarshipReferenceBrowser.js
@@ -35,6 +35,8 @@ const ScholarshipReferenceBrowser = () => {
   const [isLoading, setIsLoading] = useState(true);
   const [searchTerm, setSearchTerm] = useState("");
   const [expandedRows, setExpandedRows] = useState({});
+  const [showOnlyOpen, setShowOnlyOpen] = useState(false);
+
 
   useEffect(() => {
     const loadScholarships = async () => {
@@ -63,11 +65,11 @@ const ScholarshipReferenceBrowser = () => {
   );
 
   const filteredScholarships = useMemo(() => {
-    if (!searchTerm.trim()) {
-      return scholarships;
-    }
-    return fuseInstance.search(searchTerm.trim()).map((result) => result.item);
-  }, [fuseInstance, scholarships, searchTerm]);
+    const base = searchTerm.trim()
+      ? fuseInstance.search(searchTerm.trim()).map((result) => result.item)
+      : scholarships;
+    return showOnlyOpen ? base.filter((s) => !isReferenceClosed(s)) : base;
+  }, [fuseInstance, scholarships, searchTerm, showOnlyOpen]);
 
   const closedCount = useMemo(
     () => scholarships.filter((item) => isReferenceClosed(item)).length,
@@ -102,6 +104,12 @@ const ScholarshipReferenceBrowser = () => {
                 {closedCount.toLocaleString("en-IN")} currently closed or past
                 deadline
               </span>
+              {showOnlyOpen && (
+                <span className="rounded-full border border-[#c3e6cb] bg-[#f0fff4] px-3 py-1 text-sm text-green-800">
+                  {filteredScholarships.length.toLocaleString("en-IN")} open now
+                </span>
+              )}
+
             </div>
           )}
         </div>
@@ -121,6 +129,18 @@ const ScholarshipReferenceBrowser = () => {
             placeholder="Try: engineering, girls scholarship, Maharashtra..."
             className="w-full rounded-xl border border-[#d8c7c1] bg-[#fffdfa] px-4 py-3 text-sm text-[#2f2320] outline-none transition focus:border-[#b52326] focus:ring-2 focus:ring-[#f4d5d6]"
           />
+          <button
+            onClick={() => setShowOnlyOpen((prev) => !prev)}
+            aria-pressed={showOnlyOpen}
+            className="mt-3 flex items-center gap-3 text-sm font-semibold text-[#5b1f20]"
+          >
+            <div className={`relative h-6 w-11 rounded-full transition-colors duration-200 ${showOnlyOpen ? "bg-green-500" : "bg-[#d8c7c1]"
+              }`}>
+              <span className={`absolute left-1 top-1 h-4 w-4 rounded-full bg-white shadow-sm transition-transform duration-200 ${showOnlyOpen ? "translate-x-5" : "translate-x-0"
+                }`} />
+            </div>
+            Show open only
+          </button>
         </div>
 
         {isLoading ? (
@@ -135,7 +155,9 @@ const ScholarshipReferenceBrowser = () => {
           />
         ) : (
           <div className="rounded-2xl border border-[#eaded8] bg-white px-6 py-12 text-center text-[#5b3a34] shadow-sm">
-            No scholarships matched your search. Try a broader keyword.
+            {showOnlyOpen
+              ? "No open scholarships found. Try turning off the filter or broadening your search."
+              : "No scholarships matched your search. Try a broader keyword."}
           </div>
         )}
       </div>


### PR DESCRIPTION
Added a toggle button on the scholarships page to filter and show only scholarships that are currently open (deadline not passed).
Changes: 

ScholarshipReferenceBrowser.js : added showOnlyOpen state, wired it into the existing filteredScholarships memo, added the toggle UI and an "open now" badge

How to test

1. Go to /scholarships
2. Click the toggle : should show only scholarships with a future deadline
3. Search while toggle is on : both filters should work together
