### PR TITLE
Add normalized schema  for colleges and cutoffs

### DIFF
--- a/public/data/schema.sql
+++ b/public/data/schema.sql
@@ -1,0 +1,33 @@
+-- colleges
+CREATE TABLE colleges (
+  id SERIAL PRIMARY KEY,
+  external_id VARCHAR UNIQUE,
+  name TEXT NOT NULL,
+  state VARCHAR,
+  college_type VARCHAR,
+  management_type VARCHAR,
+  af_hierarchy SMALLINT,
+  expected_salary BIGINT,
+  salary_tier SMALLINT
+);
+
+-- Programs 
+CREATE TABLE programs (
+  id SERIAL PRIMARY KEY,
+  college_id INTEGER REFERENCES colleges(id),
+  name TEXT,
+  duration_years SMALLINT,
+  degree_type VARCHAR
+);
+
+-- Cutoffs 
+CREATE TABLE cutoffs (
+  id SERIAL PRIMARY KEY,
+  program_id INTEGER REFERENCES programs(id),
+  exam VARCHAR,
+  seat_type VARCHAR,
+  gender VARCHAR,
+  quota VARCHAR,
+  opening_rank INTEGER,
+  closing_rank INTEGER
+);


### PR DESCRIPTION
Hi! I explored the dataset in public/data and noticed that it's fully denormalized — college-level attributes (name, state, expected salary, AF hierarchy, etc.) are repeated for every cutoff row.

This leads to:
- significant duplication
- difficulty maintaining data consistency
- inefficient querying for predictions

I’m proposing a normalized structure with:
- a `colleges` table (college-level attributes)
- a `programs` table (branch/degree info)
- a `cutoffs` table (rank-based data)

While analyzing, I also noticed:
- some rows have null College IDs (so we may need a fallback key)
- inconsistent enum-like fields (gender, quota)
- program names combining degree + duration in a single string

My plan is to:
1. Propose a schema (non-breaking, additive first)
2. Write a transformation script from current JSON → normalized format
3. Keep frontend compatibility intact initially

Would love to align on schema before implementing 
---

<img width="780" height="1280" alt="idea" src="https://github.com/user-attachments/assets/6eaa36a1-6ddd-48af-9c12-dcbbc03f1208" />
