### PR TITLE
feat(api): restrict scholarship-data endpoint to GET

### DIFF
--- a/.github/ISSUE_TEMPLATE/DMP_2026.yml
+++ b/.github/ISSUE_TEMPLATE/DMP_2026.yml
@@ -31,7 +31,7 @@ body:
   - type: textarea
     id: ticket-setup
     attributes:
-      label: Setup/Installation 
+      label: Setup/Installation
       description: Please list or link setup or installation guide (if any)
 
   - type: textarea
@@ -191,11 +191,11 @@ body:
     attributes:
       label: Domain
       options:
-        - ⁠Healthcare 
+        - ⁠Healthcare
         - ⁠Education
         - Financial Inclusion
         - ⁠Livelihoods
-        - ⁠Skilling 
+        - ⁠Skilling
         - ⁠Learning & Development
         - ⁠Agriculture
         - ⁠Service Delivery
@@ -307,7 +307,7 @@ body:
 
   - type: dropdown
     id: ticket-category
-    attributes: 
+    attributes:
       label: Category
       description: Choose the categories that best describe your ticket
       multiple: true

--- a/pages/api/scholarship-data.js
+++ b/pages/api/scholarship-data.js
@@ -2,6 +2,10 @@ import fs from "fs/promises";
 import path from "path";
 
 export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    return res.status(405).json({ error: "Method not allowed" });
+  }
+
   try {
     const dataPath = path.join(
       process.cwd(),


### PR DESCRIPTION
Note: Included a small unrelated whitespace cleanup in .github/ISSUE_TEMPLATE/DMP_2026.yml because the repository’s mandatory pre-commit CI runs on push and was failing on existing trailing-whitespace violations.
This was required to unblock CI for the API endpoint change.