### PR TITLE
fix: Keep search bar visible when search returns no results

### DIFF
--- a/components/PredictedCollegeTables.js
+++ b/components/PredictedCollegeTables.js
@@ -191,6 +191,7 @@ const ROWS_PER_PAGE_INITIAL = 30; // Variable for initial rows
 
 const PredictedCollegesTable = ({
   data = [],
+  fullData = [],
   exam = "",
   searchTerm = "",
   onSearchChange = null,
@@ -751,7 +752,7 @@ const PredictedCollegesTable = ({
         </div>
       )}
       {renderLegend()}
-      {data.length > 0 && (
+      {fullData.length > 0 && (
         <div className="mb-3 flex flex-col gap-3 lg:flex-row lg:items-end lg:justify-between">
           <div className="w-full max-w-md">
             {onSearchChange && (
@@ -771,21 +772,31 @@ const PredictedCollegesTable = ({
               Showing {sortedData.length.toLocaleString("en-IN")} matching
               options.
             </p>
-            <button
-              className="w-full rounded-lg bg-[#B52326] px-4 py-2 text-white hover:bg-[#9E1F22] sm:w-auto"
-              onClick={downloadCsv}
-            >
-              Download CSV
-            </button>
+            {data.length > 0 && (
+              <button
+                className="w-full rounded-lg bg-[#B52326] px-4 py-2 text-white hover:bg-[#9E1F22] sm:w-auto"
+                onClick={downloadCsv}
+              >
+                Download CSV
+              </button>
+            )}
           </div>
         </div>
       )}
-      <div className="overflow-x-auto rounded-xl border border-[#eaded8] bg-white shadow-sm">
-        <table className={commonTableClass}>
-          <thead>{renderTableHeader()}</thead>
-          <tbody>{renderTableBody()}</tbody>
-        </table>
-      </div>
+      {data.length > 0 ? (
+        <div className="overflow-x-auto rounded-xl border border-[#eaded8] bg-white shadow-sm">
+          <table className={commonTableClass}>
+            <thead>{renderTableHeader()}</thead>
+            <tbody>{renderTableBody()}</tbody>
+          </table>
+        </div>
+      ) : fullData.length > 0 ? (
+        <div className="text-center py-10">
+          <p className="text-xl text-gray-600">
+            No results match your search term.
+          </p>
+        </div>
+      ) : null}
       {data.length > ROWS_PER_PAGE_INITIAL &&
         !showAllRows && ( // Conditional button rendering
           <div className="flex justify-center mt-4">
@@ -824,6 +835,7 @@ PredictedCollegesTable.propTypes = {
       "Salary Tier": PropTypes.string,
     })
   ),
+  fullData: PropTypes.array,
   exam: PropTypes.string.isRequired,
   searchTerm: PropTypes.string,
   onSearchChange: PropTypes.func,

--- a/pages/college_predictor.js
+++ b/pages/college_predictor.js
@@ -173,15 +173,8 @@ const CollegePredictor = () => {
 
     if (fullData.length > 0 && fuseInstance) {
       const result = fuseInstance.search(currentSearchTerm.trim());
-      if (result.length === 0) {
-        setFilteredData([]);
-        setError(
-          "No matches found for your search term within the current results."
-        );
-      } else {
-        setFilteredData(result.map((r) => r.item));
-        setError(null);
-      }
+      setFilteredData(result.map((r) => r.item));
+      setError(null);
     } else {
       setFilteredData([]);
       setError("No data to search. Apply filters to load predictions first.");
@@ -1076,10 +1069,11 @@ const CollegePredictor = () => {
                 {error}
               </p>
             </div>
-          ) : filteredData.length > 0 ? (
+          ) : fullData.length > 0 ? (
             <>
               <PredictedCollegeTables
                 data={filteredData}
+                fullData={fullData}
                 exam={queryObject.exam}
                 searchTerm={searchTerm}
                 onSearchChange={handleSearchChange}
@@ -1088,9 +1082,7 @@ const CollegePredictor = () => {
           ) : (
             <div className="text-center py-10">
               <p className="text-xl text-gray-600">
-                {fullData.length === 0 && !isLoading
-                  ? "No predictions available for your current selection. Try adjusting the filters."
-                  : "No results match your search term."}
+                No predictions available for your current selection. Try adjusting the filters.
               </p>
             </div>
           )}


### PR DESCRIPTION
## Summary
- Search bar now remains visible even when search returns no matches
- Users can easily revise their search without being trapped on a no-results screen
- Fixes issue #176

## Changes
- Updated `handleSearchChange` to not set error state on zero results
- Modified `PredictedCollegeTables` component to show search bar even with empty results
- Updated parent component to always render table component when data exists

## Testing
- Search for a term with no matches (e.g., "xyzabc")
- Verify search bar stays visible
- See "No results match your search term" message below with ability to modify search