### PR TITLE
refactor: consolidate rank-filtering logic into exam configs

### DIFF
--- a/examConfig.js
+++ b/examConfig.js
@@ -787,6 +787,13 @@ export const tneaConfig = {
     (item) => item.District === query.district || "Any" === query.district,
     (item) =>
       item["College Type"] === query.collegeType || "Any" === query.collegeType,
+    (item) => {
+      // Rank filtering for TNEA based on cutoff marks
+      if (query.rank !== undefined && query.rank !== null && query.rank !== "") {
+        return parseFloat(item["Cutoff Marks"]) <= parseFloat(query.rank);
+      }
+      return true;
+    },
   ],
 };
 
@@ -1096,6 +1103,15 @@ export const gujcetConfig = {
       (item) => {
         if (query.program) {
           return item.Program === query.program;
+        }
+        return true;
+      },
+      (item) => {
+        // Rank filtering for GUJCET based on closing marks
+        if (query.rank !== undefined && query.rank !== null && query.rank !== "") {
+          const cutoffMarks = parseFloat(item.closing_marks) || 0;
+          const userMarks = parseFloat(query.rank) || 0;
+          return userMarks >= cutoffMarks * 0.9; // Show if user marks are >= 90% of cutoff
         }
         return true;
       },

--- a/pages/api/exam-result.js
+++ b/pages/api/exam-result.js
@@ -112,91 +112,6 @@ export default async function handler(req, res) {
     // Get filters based on the exam config and query parameters
     const filters = config.getFilters(req.query);
 
-    // Helper function to parse rank (handles 'P' suffix)
-    const parseRank = (rankStr) => {
-      if (!rankStr) return null;
-      const numStr = rankStr.toString().replace(/[^0-9]/g, "");
-      return numStr ? parseInt(numStr, 10) : null;
-    };
-
-    const hasPSuffix = (rankStr) => {
-      if (!rankStr) return false;
-      return rankStr.toString().trim().toUpperCase().endsWith("P");
-    };
-
-    const rankFilter = (item) => {
-      if (exam === "GUJCET") {
-        // For GUJCET, filter based on closing_marks
-        const cutoffMarks = parseFloat(item.closing_marks) || 0;
-        const userMarks = parseFloat(rank) || 0;
-        return userMarks >= cutoffMarks * 0.9; // Show if user marks are >= 90% of cutoff
-      } else if (exam === "NEET") {
-        // For NEET, filter based on closing rank with 0.9 coefficient
-        const closingRank = parseFloat(item["Closing Rank"]) || 0;
-        const userRank = parseFloat(rank) || 0;
-        return closingRank >= 0.9 * userRank; // Show colleges where closing rank is >= 90% of user's rank
-      } else if (exam === "TNEA") {
-        return parseFloat(item["Cutoff Marks"]) <= parseFloat(rank);
-      }
-
-      const itemRankStr = item["Closing Rank"]?.toString().trim() || "";
-      const itemRank = parseRank(itemRankStr);
-      const itemHasPSuffix = hasPSuffix(itemRankStr);
-
-      if (exam === "JoSAA") {
-        if (item["Exam"] === "JEE Advanced") {
-          if (req.query.qualifiedJeeAdv !== "Yes" || !req.query.advRank)
-            return false;
-
-          const userRankStr = req.query.advRank?.toString().trim() || "";
-          const userRank = parseRank(userRankStr);
-          const userHasPSuffix = hasPSuffix(userRankStr);
-
-          // If one has 'P' suffix and the other doesn't, they don't match
-          if (itemHasPSuffix !== userHasPSuffix) return false;
-
-          return userRank && itemRank >= 0.9 * userRank;
-        } else {
-          if (!req.query.mainRank) return false;
-
-          const userRankStr = req.query.mainRank?.toString().trim() || "";
-          const userRank = parseRank(userRankStr);
-          const userHasPSuffix = hasPSuffix(userRankStr);
-
-          // If one has 'P' suffix and the other doesn't, they don't match
-          if (itemHasPSuffix !== userHasPSuffix) return false;
-
-          return userRank && itemRank >= 0.9 * userRank;
-        }
-      } else if (exam === "JEE Advanced") {
-        if (item["Exam"] !== "JEE Advanced") return false;
-        if (!req.query.advRank) return false;
-
-        const userRankStr = req.query.advRank?.toString().trim() || "";
-        const userRank = parseRank(userRankStr);
-        const userHasPSuffix = hasPSuffix(userRankStr);
-
-        // If one has 'P' suffix and the other doesn't, they don't match
-        if (itemHasPSuffix !== userHasPSuffix) return false;
-
-        return userRank && itemRank >= 0.9 * userRank;
-      } else if (exam === "JEE Main") {
-        if (item["Exam"] === "JEE Advanced") return false;
-        if (!req.query.mainRank) return false;
-
-        const userRankStr = req.query.mainRank?.toString().trim() || "";
-        const userRank = parseRank(userRankStr);
-        const userHasPSuffix = hasPSuffix(userRankStr);
-
-        // If one has 'P' suffix and the other doesn't, they don't match
-        if (itemHasPSuffix !== userHasPSuffix) return false;
-
-        return userRank && itemRank >= 0.9 * userRank;
-      } else {
-        return true;
-      }
-    };
-
     let filteredData = fullData;
 
     // Apply filters if they exist
@@ -204,11 +119,6 @@ export default async function handler(req, res) {
       filteredData = filteredData.filter((item) => {
         return filters.every((filterFn) => filterFn(item));
       });
-    }
-
-    // Apply rank filter if it exists
-    if (rankFilter) {
-      filteredData = filteredData.filter(rankFilter);
     }
 
     // Apply sorting based on exam type


### PR DESCRIPTION
## Problem
Rank-filtering logic was split between two locations:
1. Per-exam `getFilters()` in `examConfig.js` — some exams included rank-based filters
2. Hardcoded `rankFilter` function in `exam-result.js` — 70-line function with exam-specific branches

### Issues
- **Dead code**: NEET branch never executes (exam key is NEETUG, not NEET)
- **No single source of truth**: Maintenance confusion on where to add rank logic
- **Risk**: Adding new exams requires understanding which location to update

## Solution
Consolidate all rank-filtering logic into each exam's config:
- Move GUJCET rank logic to `gujcetConfig.getFilters()`
- Move TNEA rank logic to `tneaConfig.getFilters()`
- Verify JoSAA's rank logic (already consolidated)
- Remove `rankFilter()` function entirely from `exam-result.js`
- Remove unused `parseRank()` and `hasPSuffix()` helpers

## Changes
- **examConfig.js**: +16 lines (GUJCET and TNEA rank filters)
- **exam-result.js**: -90 lines (removed rankFilter and helpers)

## Benefits
- Single source of truth per exam
- Simplified code maintenance
- Cleaner separation of concerns
- Prepares for Postgres migration (each exam's filters → SQL WHERE clauses)

Fixes #180