### PR TITLE
Fix README local setup instructions for Next.js ap

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,5 +61,14 @@ The College Predictor application helps students find:
    ```
 4. Run the local development server at [http://localhost:3000](http://localhost:3000)
    ```bash
-   npm run start
+   npm run dev
    ```
+
+### Production Run
+
+If you want to run the app in production mode locally, first create a build and then start the server:
+
+```bash
+npm run build
+npm run start
+```


### PR DESCRIPTION
Fix #194 
Update the local setup instructions to use:
```
npm run dev
```
Also add a separate production section that explains:
```
npm run build
npm run start
```