### PR TITLE
fix(error): add global error boundary

### DIFF
--- a/components/ErrorBoundary.js
+++ b/components/ErrorBoundary.js
@@ -1,0 +1,146 @@
+import React from "react";
+
+const isDevelopment = process.env.NODE_ENV !== "production";
+
+class ErrorBoundary extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      hasError: false,
+      error: null,
+      errorInfo: null,
+    };
+  }
+
+  static getDerivedStateFromError(error) {
+    return {
+      hasError: true,
+      error,
+    };
+  }
+
+  componentDidCatch(error, errorInfo) {
+    this.setState({ errorInfo });
+
+    const errorContext = {
+      message: error?.message || "Unknown error",
+      stack: error?.stack || null,
+      componentStack: errorInfo?.componentStack || null,
+      pathname: typeof window !== "undefined" ? window.location.pathname : null,
+      timestamp: new Date().toISOString(),
+    };
+
+    console.error(
+      "[ErrorBoundary] Caught a React rendering error.",
+      errorContext
+    );
+
+    if (typeof this.props.onError === "function") {
+      this.props.onError(error, errorInfo, errorContext);
+    }
+  }
+
+  handleReset = () => {
+    this.setState({
+      hasError: false,
+      error: null,
+      errorInfo: null,
+    });
+  };
+
+  handleReload = () => {
+    if (typeof window !== "undefined") {
+      window.location.reload();
+    }
+  };
+
+  handleGoHome = () => {
+    if (typeof window !== "undefined") {
+      window.location.assign("/");
+    }
+  };
+
+  renderFallback() {
+    const { fallback } = this.props;
+
+    if (typeof fallback === "function") {
+      return fallback({
+        error: this.state.error,
+        errorInfo: this.state.errorInfo,
+        reset: this.handleReset,
+      });
+    }
+
+    if (fallback) {
+      return fallback;
+    }
+
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-[#fdf8f6] px-4 py-10">
+        <div
+          className="w-full max-w-lg rounded-2xl border border-[#eaded8] bg-white p-8 text-center shadow-sm"
+          role="alert"
+        >
+          <div className="mx-auto mb-4 flex h-12 w-12 items-center justify-center rounded-full bg-[#fff1f1] text-xl font-bold text-[#B52326]">
+            !
+          </div>
+          <h1 className="mb-2 text-2xl font-bold text-[#2f2320]">
+            Something went wrong
+          </h1>
+          <p className="mb-6 text-sm leading-6 text-[#5b3a34] sm:text-base">
+            The page hit an unexpected error. You can try again, reload the
+            page, or go back to the home page.
+          </p>
+
+          {isDevelopment && this.state.error && (
+            <details className="mb-6 rounded-xl border border-[#f1d3d4] bg-[#fff7f7] p-4 text-left">
+              <summary className="cursor-pointer text-sm font-semibold text-[#8f2e31]">
+                Error details
+              </summary>
+              <pre className="mt-3 overflow-x-auto whitespace-pre-wrap break-words text-xs text-[#8f2e31]">
+                {this.state.error.toString()}
+                {this.state.errorInfo?.componentStack
+                  ? `\n\n${this.state.errorInfo.componentStack}`
+                  : ""}
+              </pre>
+            </details>
+          )}
+
+          <div className="flex flex-col gap-3 sm:flex-row">
+            <button
+              type="button"
+              onClick={this.handleReset}
+              className="flex-1 rounded-lg border border-[#d8c7c1] px-4 py-2.5 font-semibold text-[#2f2320] transition hover:bg-[#f8efec]"
+            >
+              Try again
+            </button>
+            <button
+              type="button"
+              onClick={this.handleReload}
+              className="flex-1 rounded-lg bg-[#B52326] px-4 py-2.5 font-semibold text-white transition hover:bg-[#9E1F22]"
+            >
+              Reload page
+            </button>
+            <button
+              type="button"
+              onClick={this.handleGoHome}
+              className="flex-1 rounded-lg border border-[#d8c7c1] px-4 py-2.5 font-semibold text-[#2f2320] transition hover:bg-[#f8efec]"
+            >
+              Go home
+            </button>
+          </div>
+        </div>
+      </main>
+    );
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return this.renderFallback();
+    }
+
+    return this.props.children;
+  }
+}
+
+export default ErrorBoundary;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,4 +1,5 @@
 import Head from "next/head";
+import ErrorBoundary from "../components/ErrorBoundary";
 import Layout from "../components/Layout";
 import "../styles/globals.css";
 
@@ -8,9 +9,11 @@ function MyApp({ Component, pageProps }) {
       <Head>
         <link rel="icon" href="/favicon.ico" />
       </Head>
-      <Layout>
-        <Component {...pageProps} />
-      </Layout>
+      <ErrorBoundary>
+        <Layout>
+          <Component {...pageProps} />
+        </Layout>
+      </ErrorBoundary>
     </>
   );
 }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -1,11 +1,46 @@
 import { Head, Html, Main, NextScript } from "next/document";
 
+const globalErrorLoggingScript = `
+  (function () {
+    function logError(label, payload) {
+      if (window.console && typeof window.console.error === "function") {
+        window.console.error(label, payload);
+      }
+    }
+
+    window.addEventListener("error", function (event) {
+      logError("[GlobalError]", {
+        message: event.message || "Unknown runtime error",
+        source: event.filename || null,
+        line: event.lineno || null,
+        column: event.colno || null,
+        stack: event.error && event.error.stack ? event.error.stack : null,
+      });
+    });
+
+    window.addEventListener("unhandledrejection", function (event) {
+      var reason = event.reason;
+
+      logError("[UnhandledPromiseRejection]", {
+        message:
+          reason && reason.message ? reason.message : String(reason || "Unknown rejection"),
+        stack: reason && reason.stack ? reason.stack : null,
+      });
+    });
+  })();
+`;
+
 export default function Document() {
   return (
-    <Html>
+    <Html lang="en">
       <Head>
         <link rel="icon" href="/favicon.ico" />
         <link rel="shortcut icon" href="/favicon.ico" />
+        <script
+          dangerouslySetInnerHTML={{
+            __html: globalErrorLoggingScript,
+          }}
+        />
       </Head>
       <body>
         <Main />


### PR DESCRIPTION
## Problem
The application lacked a global error boundary, so if any component failed during rendering, the entire app could crash without showing users any helpful fallback UI.

## Solution
- Added a reusable `ErrorBoundary` component at `components/ErrorBoundary.js`
- Wrapped the main app layout in `pages/_app.js` so page-level and shared layout errors are caught
- Added a user-friendly fallback UI with:
  - Try again
  - Reload page
  - Go home
- Added error logging inside the boundary using `componentDidCatch`
- Added global browser error and unhandled promise rejection logging in `pages/_document.js`

## Impact
Users now see a graceful error screen instead of a blank crashed page, and errors are easier to debug from console logs.

## Files Changed
- `components/ErrorBoundary.js` - new global error boundary component
- `pages/_app.js` - wrapped app with error boundary
- `pages/_document.js` - added global client-side error logging script

## Testing
- Built the app successfully with `npm run build`
- Verified the app compiles after adding the boundary
- Manual test recommended by intentionally throwing an error in a component
- Confirm fallback UI appears
- Confirm console logs show captured errors

## Notes
React error boundaries catch rendering errors in the component tree.  
`_document.js` was used only for global browser error logging, not as a React error boundary.

## Closes
Closes #197 
