### PR TITLE
Fix JoSAA program filtering and unsupported PwD rank estimation

### DIFF
--- a/examConfig.js
+++ b/examConfig.js
@@ -137,15 +137,16 @@ export const jeeMainJosaaConfig = {
     );
   },
   getFilters: (query) => {
+    const normalizedProgram = String(query.program || "").toLowerCase();
     const baseFilters = [
       (item) => item.Exam === query.code,
       (item) => item.Gender === query.gender,
       (item) => {
-        if (query.program === "Architecture") {
+        if (normalizedProgram === "architecture") {
           return item["Academic Program Name"]
             .toLowerCase()
             .includes("architecture");
-        } else if (query.program === "Planning") {
+        } else if (normalizedProgram === "planning") {
           return item["Academic Program Name"]
             .toLowerCase()
             .includes("planning");
@@ -872,14 +873,15 @@ export const josaaConfig = {
     );
   },
   getFilters: (query) => {
+    const normalizedProgram = String(query.program || "").toLowerCase();
     const baseFilters = [
       (item) => item.Gender === query.gender || item.Gender === "All",
       (item) => {
-        if (query.program === "architecture") {
+        if (normalizedProgram === "architecture") {
           return item["Academic Program Name"]
             .toLowerCase()
             .includes("architecture");
-        } else if (query.program === "planning") {
+        } else if (normalizedProgram === "planning") {
           return item["Academic Program Name"]
             .toLowerCase()
             .includes("planning");

--- a/pages/api/jee-predict.js
+++ b/pages/api/jee-predict.js
@@ -64,7 +64,16 @@ const F4_C4_B = -1146;
 const F4_C5_M = 0.0396;
 const F4_C5_B = -11081;
 
-const ALLOWED_CATEGORIES = new Set(["OPEN", "OBC-NCL", "SC", "ST", "EWS"]);
+const ESTIMATION_SUPPORTED_CATEGORIES = new Set([
+  "OPEN",
+  "OBC-NCL",
+  "SC",
+  "ST",
+  "EWS",
+]);
+const PWD_CATEGORY_SUFFIX = "(PwD)";
+const PWD_CATEGORY_ERROR =
+  "Rank estimation is currently unavailable for PwD categories. Please switch to 'No, I know my rank' and enter your rank directly.";
 
 const marksToPercentage = (score) => (score * 100) / TOTAL_MARKS;
 const percentageToMarks = (percentage) =>
@@ -175,7 +184,11 @@ export default function handler(req, res) {
   const percentileRaw = body?.percentile;
   const category = body?.category;
 
-  if (!ALLOWED_CATEGORIES.has(category)) {
+  if (String(category || "").includes(PWD_CATEGORY_SUFFIX)) {
+    return res.status(400).json({ error: PWD_CATEGORY_ERROR });
+  }
+
+  if (!ESTIMATION_SUPPORTED_CATEGORIES.has(category)) {
     return res
       .status(400)
       .json({ error: "Unsupported category for estimation" });

--- a/pages/college_predictor.js
+++ b/pages/college_predictor.js
@@ -95,6 +95,20 @@ const getCleanQueryObject = (query) =>
     )
   );
 
+const josaaEstimationSupportedCategories = new Set([
+  "OPEN",
+  "OBC-NCL",
+  "SC",
+  "ST",
+  "EWS",
+]);
+
+const isJosaaEstimationSupportedCategory = (category) =>
+  josaaEstimationSupportedCategories.has(category);
+
+const josaaPwdEstimateError =
+  "Rank estimation is currently unavailable for PwD categories. Please switch to 'No,I know my rank' and enter your rank directly.";
+
 const CollegePredictor = () => {
   const router = useRouter();
   const [filteredData, setFilteredData] = useState([]);
@@ -484,6 +498,10 @@ const CollegePredictor = () => {
       setEstimateError("Please select your category first.");
       return;
     }
+    if (!isJosaaEstimationSupportedCategory(queryObject.category)) {
+      setEstimateError(josaaPwdEstimateError);
+      return;
+    }
     if (estimateInputType === "marks") {
       if (marksInput === "") {
         setMarksError("Please enter your marks.");
@@ -816,12 +834,21 @@ const CollegePredictor = () => {
                       (estimateInputType === "marks"
                         ? marksInput === "" || !!marksError
                         : percentileInput === "" || !!percentileError) ||
-                      !queryObject.category
+                      !queryObject.category ||
+                      !isJosaaEstimationSupportedCategory(queryObject.category)
                     }
                     className="w-full rounded-lg bg-[#B52326] px-4 py-2 text-white hover:bg-[#9E1F22] disabled:bg-gray-300 disabled:text-gray-600"
                   >
                     {isEstimating ? "Estimating..." : "Estimate Rank"}
                   </button>
+                  {queryObject.category &&
+                    !isJosaaEstimationSupportedCategory(
+                      queryObject.category
+                    ) && (
+                      <p className="text-sm text-[#6d5550]">
+                        {josaaPwdEstimateError}
+                      </p>
+                    )}
                   {estimateError && (
                     <p className="text-sm text-red-500">{estimateError}</p>
                   )}

--- a/pages/index.js
+++ b/pages/index.js
@@ -69,6 +69,20 @@ const normalizePrimaryInputValue = (exam, value) => {
 const getCleanQueryEntries = (data) =>
   Object.entries(data).filter(([, value]) => value !== undefined && value !== null && value !== "");
 
+const josaaEstimationSupportedCategories = new Set([
+  "OPEN",
+  "OBC-NCL",
+  "SC",
+  "ST",
+  "EWS",
+]);
+
+const isJosaaEstimationSupportedCategory = (category) =>
+  josaaEstimationSupportedCategories.has(category);
+
+const josaaPwdEstimateError =
+  "Rank estimation is currently unavailable for PwD categories. Please switch to 'No, I know my rank' and enter your rank directly.";
+
 const ExamForm = () => {
   const [selectedExam, setSelectedExam] = useState("");
   const [formData, setFormData] = useState({});
@@ -243,6 +257,10 @@ const ExamForm = () => {
   const handleEstimateRank = async () => {
     if (!formData.category) {
       setEstimateError("Please select your category first.");
+      return;
+    }
+    if (!isJosaaEstimationSupportedCategory(formData.category)) {
+      setEstimateError(josaaPwdEstimateError);
       return;
     }
     if (estimateInputType === "marks") {
@@ -757,12 +775,23 @@ const ExamForm = () => {
                                 ? marksInput === "" || !!marksError
                                 : percentileInput === "" ||
                                   !!percentileError) ||
-                              !formData.category
+                              !formData.category ||
+                              !isJosaaEstimationSupportedCategory(
+                                formData.category
+                              )
                             }
                             className="rounded-lg bg-[#B52326] px-4 py-2 text-white hover:bg-[#9E1F22] disabled:bg-gray-300 disabled:text-gray-600"
                           >
                             {isEstimating ? "Estimating..." : "Estimate Rank"}
                           </button>
+                          {formData.category &&
+                            !isJosaaEstimationSupportedCategory(
+                              formData.category
+                            ) && (
+                              <p className="text-sm text-[#6d5550]">
+                                {josaaPwdEstimateError}
+                              </p>
+                            )}
                           {estimateError && (
                             <p className="text-red-500 text-sm">
                               {estimateError}


### PR DESCRIPTION
Resolves #202 

This PR fixes two JoSAA bugs:

- Fixes program filtering so `Architecture` and `Planning` selections no longer fall back to Engineering results
- Makes unsupported PwD rank estimation explicit by blocking that path in the UI and returning a clear API error

## Changes

- Normalized JoSAA `program` values before applying filter logic
- Added explicit handling for unsupported PwD categories in the estimator API
- Disabled estimation submission for unsupported PwD categories in the JoSAA UI
- Added a user-facing message guiding users to switch to known-rank mode

## Why

Previously:
- Users selecting `Architecture` or `Planning` could receive incorrect Engineering results
- PwD users could enter the estimation flow, but the backend rejected the request with a vague unsupported-category error

This PR makes the filtering correct and the unsupported estimator path clear and safe.

## Validation

- `npm run build` passes
- Verified that Architecture queries match architecture rows and exclude engineering rows

## Notes

This PR does not attempt to estimate PwD ranks using non-PwD category coefficients, since that would risk misleading users. It only makes the current support boundary explicit.
