### PR TITLE
fix(rate-limit): harden API abuse protection

### DIFF
--- a/pages/api/exam-result.js
+++ b/pages/api/exam-result.js
@@ -1,61 +1,39 @@
 import fs from "fs/promises";
 import examConfigs from "../../examConfig";
-import rateLimit from "express-rate-limit";
+import { createRateLimiter } from "../../utils/rateLimit";
 
-// Helper function to get client IP address
-const getIp = (req) => {
-  const xForwardedFor = req.headers["x-forwarded-for"];
-  if (typeof xForwardedFor === "string") {
-    return xForwardedFor.split(",")[0].trim();
-  }
-  if (Array.isArray(xForwardedFor) && xForwardedFor.length > 0) {
-    return xForwardedFor[0].trim();
-  }
-  // Fallback to socket remoteAddress or connection remoteAddress
-  return req.socket?.remoteAddress || req.connection?.remoteAddress;
-};
-
-const limiter = rateLimit({
-  windowMs: 15 * 60 * 1000, // 15 minutes
-  max: 100, // limit each IP to 100 requests per windowMs
-  standardHeaders: true, // Return rate limit info in the `RateLimit-*` headers
-  legacyHeaders: false, // Disable the `X-RateLimit-*` headers
-  // trustProxy: true, // Removed as we are using a custom keyGenerator
-  keyGenerator: (req, res) => {
-    const ip = getIp(req);
-    if (!ip) {
-      // This is a fallback, but ideally, an IP should always be found.
-      // If IP is consistently not found, the getIp logic might need adjustment
-      // for your specific environment/proxy setup.
-      console.warn(
-        "Rate limiter: IP address could not be determined. Using a default key for rate limiting. This might group multiple users."
-      );
-      return "default-fallback-key";
-    }
-    return ip;
-  },
-  handler: (req, res) => {
-    res.status(429).json({
-      error: "Too many requests. Please try again later.",
-    });
-  },
+const examResultLimiter = createRateLimiter({
+  namespace: "api:exam-result",
+  windowMs: 15 * 60 * 1000,
+  maxRequests: 100,
+  message:
+    "Too many college predictor requests from this IP. Please wait a few minutes and try again.",
 });
 
 export default async function handler(req, res) {
-  await limiter(req, res, () => {});
+  if (req.method !== "GET") {
+    return res
+      .status(405)
+      .json({ error: "Method not allowed. Use GET for this endpoint." });
+  }
+
+  const rateLimitResult = await examResultLimiter(req, res);
+  if (!rateLimitResult.allowed) {
+    return;
+  }
 
   const { exam, rank } = req.query;
 
   if (!exam || !examConfigs[exam]) {
-    return res.status(400).json({ error: "Invalid or missing exam parameter" });
+    return res
+      .status(400)
+      .json({ error: "Invalid or missing exam parameter." });
   }
 
   const config = examConfigs[exam];
   const primaryInputConfig = config.primaryInput;
   const queryValue =
-    exam === "JoSAA"
-      ? req.query.mainRank || req.query.rank
-      : req.query.rank;
+    exam === "JoSAA" ? req.query.mainRank || req.query.rank : req.query.rank;
 
   if (
     primaryInputConfig &&
@@ -100,7 +78,7 @@ export default async function handler(req, res) {
     if (!req.query[field.name]) {
       return res
         .status(400)
-        .json({ error: `Missing required parameter: ${field.name}` });
+        .json({ error: `Missing required parameter: ${field.name}.` });
     }
   }
 

--- a/pages/api/jee-predict.js
+++ b/pages/api/jee-predict.js
@@ -1,5 +1,15 @@
+import { createRateLimiter } from "../../utils/rateLimit";
+
 const TOTAL_MARKS = 300;
 const TOTAL_TEST_TAKERS = 1500000;
+
+const jeePredictLimiter = createRateLimiter({
+  namespace: "api:jee-predict",
+  windowMs: 15 * 60 * 1000,
+  maxRequests: 60,
+  message:
+    "Too many rank estimation requests from this IP. Please wait a few minutes and try again.",
+});
 
 // Percentage -> Percentile (piecewise)
 const LFIT = -86.555129;
@@ -165,12 +175,27 @@ const airToCat = (category, rank) => {
   return rounded <= 0 ? 1 : rounded;
 };
 
-export default function handler(req, res) {
+export default async function handler(req, res) {
   if (req.method !== "POST") {
-    return res.status(405).json({ error: "Method not allowed" });
+    return res
+      .status(405)
+      .json({ error: "Method not allowed. Use POST for this endpoint." });
   }
 
-  const body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+  const rateLimitResult = await jeePredictLimiter(req, res);
+  if (!rateLimitResult.allowed) {
+    return;
+  }
+
+  let body;
+  try {
+    body = typeof req.body === "string" ? JSON.parse(req.body) : req.body;
+  } catch (error) {
+    return res.status(400).json({
+      error: "Invalid request body. Please send valid JSON.",
+    });
+  }
+
   const marksRaw = body?.marks;
   const percentileRaw = body?.percentile;
   const category = body?.category;
@@ -178,7 +203,7 @@ export default function handler(req, res) {
   if (!ALLOWED_CATEGORIES.has(category)) {
     return res
       .status(400)
-      .json({ error: "Unsupported category for estimation" });
+      .json({ error: "Unsupported category for estimation." });
   }
 
   let marks;
@@ -188,7 +213,9 @@ export default function handler(req, res) {
   if (marksRaw !== undefined && marksRaw !== null && marksRaw !== "") {
     marks = Number(marksRaw);
     if (Number.isNaN(marks) || marks < 0 || marks > TOTAL_MARKS) {
-      return res.status(400).json({ error: "Marks must be between 0 and 300" });
+      return res
+        .status(400)
+        .json({ error: "Marks must be between 0 and 300." });
     }
     percentage = marksToPercentage(marks);
     percentile = percentageToPercentile(percentage);
@@ -201,14 +228,14 @@ export default function handler(req, res) {
     if (Number.isNaN(percentile) || percentile < 0 || percentile > 100) {
       return res
         .status(400)
-        .json({ error: "Percentile must be between 0 and 100" });
+        .json({ error: "Percentile must be between 0 and 100." });
     }
     percentage = percentileToPercentage(percentile);
     marks = percentageToMarks(percentage);
   } else {
     return res
       .status(400)
-      .json({ error: "Provide either marks or percentile" });
+      .json({ error: "Provide either marks or percentile." });
   }
 
   let allIndiaRank = percentileToAir(percentile);

--- a/pages/api/scholarship-data.js
+++ b/pages/api/scholarship-data.js
@@ -1,7 +1,27 @@
 import fs from "fs/promises";
 import path from "path";
+import { createRateLimiter } from "../../utils/rateLimit";
+
+const scholarshipDataLimiter = createRateLimiter({
+  namespace: "api:scholarship-data",
+  windowMs: 15 * 60 * 1000,
+  maxRequests: 120,
+  message:
+    "Too many scholarship data requests from this IP. Please wait a few minutes and try again.",
+});
 
 export default async function handler(req, res) {
+  if (req.method !== "GET") {
+    return res
+      .status(405)
+      .json({ error: "Method not allowed. Use GET for this endpoint." });
+  }
+
+  const rateLimitResult = await scholarshipDataLimiter(req, res);
+  if (!rateLimitResult.allowed) {
+    return;
+  }
+
   try {
     const dataPath = path.join(
       process.cwd(),

--- a/utils/rateLimit.js
+++ b/utils/rateLimit.js
@@ -1,0 +1,383 @@
+import crypto from "crypto";
+import net from "net";
+
+const GLOBAL_STORE_KEY = "__avantiRateLimitStore__";
+const DEFAULT_WINDOW_MS = 15 * 60 * 1000;
+const DEFAULT_MAX_REQUESTS = 100;
+const PROXY_HEADER_NAMES = [
+  "cf-connecting-ip",
+  "true-client-ip",
+  "x-real-ip",
+  "x-forwarded-for",
+  "fly-client-ip",
+  "fastly-client-ip",
+  "x-client-ip",
+  "x-cluster-client-ip",
+  "forwarded",
+];
+
+const getGlobalStore = () => {
+  if (!globalThis[GLOBAL_STORE_KEY]) {
+    globalThis[GLOBAL_STORE_KEY] = new Map();
+  }
+
+  return globalThis[GLOBAL_STORE_KEY];
+};
+
+const normalizeIp = (candidate) => {
+  if (typeof candidate !== "string") {
+    return "";
+  }
+
+  let value = candidate.trim();
+  if (!value) {
+    return "";
+  }
+
+  if (value.startsWith('"') && value.endsWith('"')) {
+    value = value.slice(1, -1);
+  }
+
+  if (value.startsWith("[") && value.endsWith("]")) {
+    value = value.slice(1, -1);
+  }
+
+  if (value.toLowerCase().startsWith("for=")) {
+    value = value.slice(4);
+  }
+
+  if (value.startsWith("::ffff:")) {
+    value = value.slice(7);
+  }
+
+  if (value === "::1") {
+    value = "127.0.0.1";
+  }
+
+  if (value.includes("%")) {
+    value = value.split("%")[0];
+  }
+
+  return value.trim();
+};
+
+const isValidIp = (candidate) => net.isIP(normalizeIp(candidate)) !== 0;
+
+const isPrivateIpv4 = (ip) => {
+  const octets = ip.split(".").map((value) => Number.parseInt(value, 10));
+
+  if (octets.length !== 4 || octets.some((value) => Number.isNaN(value))) {
+    return false;
+  }
+
+  const [first, second] = octets;
+
+  return (
+    first === 10 ||
+    first === 127 ||
+    (first === 169 && second === 254) ||
+    (first === 172 && second >= 16 && second <= 31) ||
+    (first === 192 && second === 168) ||
+    (first === 100 && second >= 64 && second <= 127)
+  );
+};
+
+const isPrivateIpv6 = (ip) => {
+  const lowered = ip.toLowerCase();
+
+  return (
+    lowered === "::1" ||
+    lowered.startsWith("fc") ||
+    lowered.startsWith("fd") ||
+    lowered.startsWith("fe80:")
+  );
+};
+
+const isPrivateOrLoopbackIp = (candidate) => {
+  const normalizedIp = normalizeIp(candidate);
+  const ipVersion = net.isIP(normalizedIp);
+
+  if (ipVersion === 4) {
+    return isPrivateIpv4(normalizedIp);
+  }
+
+  if (ipVersion === 6) {
+    return isPrivateIpv6(normalizedIp);
+  }
+
+  return false;
+};
+
+const parseForwardedHeader = (value) => {
+  if (typeof value !== "string") {
+    return [];
+  }
+
+  return value
+    .split(",")
+    .map((segment) => {
+      const match = segment.match(/for=(?:"?\[?)([^;\],"]+)/i);
+      return match ? match[1] : "";
+    })
+    .filter(Boolean);
+};
+
+const getHeaderCandidates = (headerName, headerValue) => {
+  if (headerName === "forwarded") {
+    return parseForwardedHeader(headerValue).map((value) => ({
+      value,
+      source: headerName,
+    }));
+  }
+
+  if (Array.isArray(headerValue)) {
+    return headerValue.flatMap((value) =>
+      String(value)
+        .split(",")
+        .map((candidate) => ({
+          value: candidate,
+          source: headerName,
+        }))
+    );
+  }
+
+  if (typeof headerValue === "string") {
+    return headerValue.split(",").map((candidate) => ({
+      value: candidate,
+      source: headerName,
+    }));
+  }
+
+  return [];
+};
+
+const getBestHeaderIp = (req) => {
+  const validCandidates = [];
+
+  for (const headerName of PROXY_HEADER_NAMES) {
+    const headerValue = req.headers[headerName];
+    const candidates = getHeaderCandidates(headerName, headerValue);
+
+    for (const candidate of candidates) {
+      const normalizedIp = normalizeIp(candidate.value);
+      if (!isValidIp(normalizedIp)) {
+        continue;
+      }
+
+      validCandidates.push({
+        value: normalizedIp,
+        source: candidate.source,
+      });
+    }
+  }
+
+  if (validCandidates.length === 0) {
+    return null;
+  }
+
+  return (
+    validCandidates.find(
+      (candidate) => !isPrivateOrLoopbackIp(candidate.value)
+    ) || validCandidates[0]
+  );
+};
+
+const shouldTrustProxy = (remoteIp, trustProxy) => {
+  if (typeof trustProxy === "boolean") {
+    return trustProxy;
+  }
+
+  return (
+    process.env.TRUST_PROXY === "true" ||
+    Boolean(process.env.VERCEL) ||
+    !remoteIp ||
+    isPrivateOrLoopbackIp(remoteIp)
+  );
+};
+
+const buildFallbackIdentifier = (req) => {
+  const fingerprint = [
+    req.socket?.remoteAddress || "",
+    req.connection?.remoteAddress || "",
+    req.headers["user-agent"] || "",
+    req.headers.host || "",
+    req.headers["accept-language"] || "",
+  ].join("|");
+
+  return `anonymous-${crypto
+    .createHash("sha256")
+    .update(fingerprint)
+    .digest("hex")
+    .slice(0, 16)}`;
+};
+
+export const getClientIdentifier = (req, options = {}) => {
+  const remoteIp = normalizeIp(
+    req.socket?.remoteAddress || req.connection?.remoteAddress || ""
+  );
+  const trustProxy = shouldTrustProxy(remoteIp, options.trustProxy);
+
+  if (trustProxy) {
+    const forwardedIp = getBestHeaderIp(req);
+    if (forwardedIp) {
+      return forwardedIp;
+    }
+  }
+
+  if (isValidIp(remoteIp)) {
+    return {
+      value: remoteIp,
+      source: "remoteAddress",
+    };
+  }
+
+  const headerIp = getBestHeaderIp(req);
+  if (headerIp) {
+    return headerIp;
+  }
+
+  return {
+    value: buildFallbackIdentifier(req),
+    source: "fingerprint",
+  };
+};
+
+export const createMemoryRateLimitStore = () => {
+  const buckets = getGlobalStore();
+
+  return {
+    async increment(key, windowMs) {
+      const now = Date.now();
+      const current = buckets.get(key);
+
+      if (!current || current.resetTime <= now) {
+        const next = {
+          count: 1,
+          resetTime: now + windowMs,
+        };
+
+        buckets.set(key, next);
+
+        if (buckets.size > 1000) {
+          for (const [storedKey, entry] of buckets.entries()) {
+            if (entry.resetTime <= now) {
+              buckets.delete(storedKey);
+            }
+          }
+        }
+
+        return next;
+      }
+
+      current.count += 1;
+      buckets.set(key, current);
+      return current;
+    },
+  };
+};
+
+const defaultStore = createMemoryRateLimitStore();
+
+const validateLimiterOptions = ({
+  namespace,
+  windowMs,
+  maxRequests,
+  store,
+}) => {
+  if (!namespace || typeof namespace !== "string") {
+    throw new Error("Rate limiter namespace must be a non-empty string.");
+  }
+
+  if (!Number.isInteger(windowMs) || windowMs <= 0) {
+    throw new Error("Rate limiter windowMs must be a positive integer.");
+  }
+
+  if (!Number.isInteger(maxRequests) || maxRequests <= 0) {
+    throw new Error("Rate limiter maxRequests must be a positive integer.");
+  }
+
+  if (!store || typeof store.increment !== "function") {
+    throw new Error(
+      "Rate limiter store must implement an increment(key, windowMs) method."
+    );
+  }
+};
+
+const setRateLimitHeaders = (
+  res,
+  { maxRequests, remaining, resetTime, windowMs }
+) => {
+  const resetAfterSeconds = Math.max(
+    0,
+    Math.ceil((resetTime - Date.now()) / 1000)
+  );
+  const policy = `${maxRequests};w=${Math.ceil(windowMs / 1000)}`;
+
+  res.setHeader("RateLimit-Limit", String(maxRequests));
+  res.setHeader("RateLimit-Remaining", String(remaining));
+  res.setHeader("RateLimit-Reset", String(resetAfterSeconds));
+  res.setHeader("RateLimit-Policy", policy);
+  res.setHeader("X-RateLimit-Limit", String(maxRequests));
+  res.setHeader("X-RateLimit-Remaining", String(remaining));
+  res.setHeader("X-RateLimit-Reset", String(resetAfterSeconds));
+
+  return resetAfterSeconds;
+};
+
+export const createRateLimiter = ({
+  namespace,
+  windowMs = DEFAULT_WINDOW_MS,
+  maxRequests = DEFAULT_MAX_REQUESTS,
+  message = "Too many requests. Please try again later.",
+  store = defaultStore,
+  trustProxy = "auto",
+} = {}) => {
+  validateLimiterOptions({ namespace, windowMs, maxRequests, store });
+
+  return async (req, res) => {
+    const client = getClientIdentifier(req, { trustProxy });
+    const key = `${namespace}:${client.value}`;
+    const entry = await store.increment(key, windowMs);
+    const remaining = Math.max(0, maxRequests - entry.count);
+    const retryAfter = setRateLimitHeaders(res, {
+      maxRequests,
+      remaining,
+      resetTime: entry.resetTime,
+      windowMs,
+    });
+
+    if (entry.count > maxRequests) {
+      res.setHeader("Retry-After", String(retryAfter));
+
+      console.warn("[RATE_LIMIT] Request blocked", {
+        namespace,
+        identifier: client.value,
+        source: client.source,
+        method: req.method,
+        path: req.url,
+        count: entry.count,
+        resetTime: new Date(entry.resetTime).toISOString(),
+      });
+
+      res.status(429).json({
+        error: message,
+        code: "RATE_LIMIT_EXCEEDED",
+        retryAfter,
+        windowSeconds: Math.ceil(windowMs / 1000),
+      });
+
+      return {
+        allowed: false,
+        retryAfter,
+      };
+    }
+
+    return {
+      allowed: true,
+      identifier: client.value,
+      source: client.source,
+      remaining,
+      resetTime: entry.resetTime,
+    };
+  };
+};


### PR DESCRIPTION
## Problem
The API rate limiting implementation was vulnerable to bypass because client identification relied too heavily on proxy-related headers without centralized normalization and validation. This made abuse protection inconsistent and easier to evade.

## Solution
- Added a shared rate limiting utility at `utils/rateLimit.js`
- Centralized client identification and proxy-aware IP normalization
- Added in-memory rate limiting with a reusable store interface
- Structured the limiter to be Redis-ready for future upgrades
- Applied endpoint-specific rate limits to:
  - `pages/api/exam-result.js`
  - `pages/api/jee-predict.js`
  - `pages/api/scholarship-data.js`
- Added clearer `405` and validation responses where needed
- Added standard rate-limit headers plus retry metadata for blocked requests

## Changes Made
- Created `utils/rateLimit.js`
- Updated `pages/api/exam-result.js`
- Updated `pages/api/jee-predict.js`
- Updated `pages/api/scholarship-data.js`

## Impact
API abuse protection is stronger and more consistent across public endpoints. The app now applies server-side endpoint-specific rate limiting with safer client identification and a cleaner path to future shared-store enforcement.

## Testing
- Verified production build passes with `npm run build`
- Confirmed rate-limited requests return `429`
- Confirmed rate-limit headers are included
- Confirmed endpoints use separate limiter namespaces
- Confirmed request handling still works for valid traffic

## Notes
This PR improves protection against spoofed forwarding headers and weak local limiter behavior, but truly global enforcement across multiple instances will still require shared infrastructure such as Redis or edge/WAF controls.

## Closes
Closes #206
