### PR TITLE
feat(api): add retry logic for client requests

### DIFF
--- a/components/ScholarshipReferenceBrowser.js
+++ b/components/ScholarshipReferenceBrowser.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useMemo, useState } from "react";
 import Fuse from "fuse.js";
 import ScholarshipTable from "./ScholarshipTable";
+import { createRetryMessage, fetchJsonWithRetry } from "../utils/apiClient";
 
 const fuseOptions = {
   includeScore: false,
@@ -12,7 +13,9 @@ const fuseOptions = {
 
 const parseDeadline = (value) => {
   if (!value) return null;
-  const parts = String(value).split("/").map((part) => Number(part));
+  const parts = String(value)
+    .split("/")
+    .map((part) => Number(part));
   if (parts.length !== 3 || parts.some((part) => Number.isNaN(part))) {
     return null;
   }
@@ -30,32 +33,74 @@ const isReferenceClosed = (scholarship) => {
   return deadline < now;
 };
 
-const ScholarshipReferenceBrowser = () => {
+const ScholarshipReferenceBrowser = ({ retryOptions }) => {
   const [scholarships, setScholarships] = useState([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState("");
+  const [retryNotice, setRetryNotice] = useState("");
   const [searchTerm, setSearchTerm] = useState("");
   const [expandedRows, setExpandedRows] = useState({});
 
   useEffect(() => {
+    let isCancelled = false;
+
     const loadScholarships = async () => {
+      setIsLoading(true);
+      setError("");
+      setRetryNotice("");
+
       try {
-        const response = await fetch("/data/scholarships/scholarship_data.json");
-        const data = await response.json();
+        const { data } = await fetchJsonWithRetry(
+          "/data/scholarships/scholarship_data.json",
+          {},
+          {
+            ...retryOptions,
+            onRetry: ({ attempt, maxRetries, delayMs }) => {
+              if (isCancelled) return;
+
+              setRetryNotice(
+                createRetryMessage({
+                  attempt,
+                  maxRetries,
+                  delayMs,
+                  resourceLabel: "Loading scholarships",
+                })
+              );
+            },
+          }
+        );
         const sortedData = [...data].sort((a, b) =>
           String(a["Scholarship Name"] || "").localeCompare(
             String(b["Scholarship Name"] || "")
           )
         );
-        setScholarships(sortedData);
+        if (!isCancelled) {
+          setScholarships(sortedData);
+          setError("");
+        }
       } catch (error) {
         console.error("Failed to load scholarship reference data:", error);
+        if (!isCancelled) {
+          setError(
+            error.message ||
+              "Failed to load scholarship reference data. Please try again."
+          );
+          setScholarships([]);
+        }
       } finally {
-        setIsLoading(false);
+        if (!isCancelled) {
+          setIsLoading(false);
+          setRetryNotice("");
+        }
       }
     };
 
     loadScholarships();
-  }, []);
+
+    return () => {
+      isCancelled = true;
+    };
+  }, [retryOptions]);
 
   const fuseInstance = useMemo(
     () => new Fuse(scholarships, fuseOptions),
@@ -125,7 +170,14 @@ const ScholarshipReferenceBrowser = () => {
 
         {isLoading ? (
           <div className="rounded-2xl border border-[#eaded8] bg-white px-6 py-12 text-center text-[#5b3a34] shadow-sm">
-            Loading scholarship reference list...
+            <p>Loading scholarship reference list...</p>
+            {retryNotice && (
+              <p className="mt-3 text-sm text-[#8f2e31]">{retryNotice}</p>
+            )}
+          </div>
+        ) : error ? (
+          <div className="rounded-2xl border border-[#f0c7c8] bg-[#fff1f1] px-6 py-12 text-center text-[#8f2e31] shadow-sm">
+            {error}
           </div>
         ) : filteredScholarships.length > 0 ? (
           <ScholarshipTable

--- a/pages/college_predictor.js
+++ b/pages/college_predictor.js
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useRef } from "react";
 import { useRouter } from "next/router";
 import getConstants from "../constants";
 import PredictedCollegeTables from "../components/PredictedCollegeTables";
@@ -8,6 +8,7 @@ import examConfigs from "../examConfig";
 import dynamic from "next/dynamic";
 import TneaScoreCalculator from "../components/TneaScoreCalculator";
 import { debounce } from "lodash";
+import { createRetryMessage, fetchJsonWithRetry } from "../utils/apiClient";
 
 // Dynamically import Dropdown with SSR disabled
 const Dropdown = dynamic(() => import("../components/dropdown"), {
@@ -59,17 +60,11 @@ const validatePrimaryInputValue = (exam, value) => {
     return "Please enter a valid value.";
   }
 
-  if (
-    inputConfig.min !== undefined &&
-    numericValue < Number(inputConfig.min)
-  ) {
+  if (inputConfig.min !== undefined && numericValue < Number(inputConfig.min)) {
     return rangeMessage;
   }
 
-  if (
-    inputConfig.max !== undefined &&
-    numericValue > Number(inputConfig.max)
-  ) {
+  if (inputConfig.max !== undefined && numericValue > Number(inputConfig.max)) {
     return rangeMessage;
   }
 
@@ -95,6 +90,19 @@ const getCleanQueryObject = (query) =>
     )
   );
 
+const predictionRetryOptions = {
+  maxRetries: 3,
+  initialDelayMs: 400,
+  maxDelayMs: 3000,
+};
+
+const estimateRetryOptions = {
+  maxRetries: 2,
+  initialDelayMs: 400,
+  maxDelayMs: 2000,
+  safeToRetry: true,
+};
+
 const CollegePredictor = () => {
   const router = useRouter();
   const [filteredData, setFilteredData] = useState([]);
@@ -110,12 +118,16 @@ const CollegePredictor = () => {
   const [percentileError, setPercentileError] = useState("");
   const [estimateInputType, setEstimateInputType] = useState("marks");
   const [estimateError, setEstimateError] = useState("");
+  const [requestRetryNotice, setRequestRetryNotice] = useState("");
+  const [estimateRetryNotice, setEstimateRetryNotice] = useState("");
   const [estimatedRank, setEstimatedRank] = useState(null);
   const [estimatedPercentile, setEstimatedPercentile] = useState(null);
   const [isEstimating, setIsEstimating] = useState(false);
   const [currentExam, setCurrentExam] = useState(null);
   const [showSelectionDetails, setShowSelectionDetails] = useState(false);
   const [primaryInputError, setPrimaryInputError] = useState("");
+  const dataRequestIdRef = useRef(0);
+  const estimateRequestIdRef = useRef(0);
 
   useEffect(() => {
     // Initialize queryObject from router.query
@@ -189,47 +201,70 @@ const CollegePredictor = () => {
   };
 
   const fetchData = async (query) => {
+    const requestId = ++dataRequestIdRef.current;
     setIsLoading(true);
     setError(null);
     setSearchTerm("");
+    setRequestRetryNotice("");
     try {
       const params = new URLSearchParams(
         Object.entries(getCleanQueryObject(query))
       );
       const queryString = params.toString();
       if (queryString === "") {
-        setIsLoading(false);
+        if (requestId === dataRequestIdRef.current) {
+          setIsLoading(false);
+        }
         return;
       }
-      const response = await fetch(`/api/exam-result?${queryString}`);
-      if (!response.ok) {
-        let errorMessage = `HTTP error! status: ${response.status}`;
-        try {
-          const errorData = await response.json();
-          if (errorData?.error) {
-            errorMessage = errorData.error;
-          }
-        } catch (parseError) {}
+      const { data } = await fetchJsonWithRetry(
+        `/api/exam-result?${queryString}`,
+        {},
+        {
+          ...predictionRetryOptions,
+          onRetry: ({ attempt, maxRetries, delayMs }) => {
+            if (requestId !== dataRequestIdRef.current) return;
 
-        if (response.status === 429) {
-          setError("Rate limit exceeded. Please try again later.");
-        } else {
-          setError(errorMessage);
+            setRequestRetryNotice(
+              createRetryMessage({
+                attempt,
+                maxRetries,
+                delayMs,
+                resourceLabel: "Fetching predictions",
+              })
+            );
+          },
         }
-        setFullData([]);
-        setFilteredData([]);
-      } else {
-        const data = await response.json();
-        setFullData(data);
-        setFilteredData(data);
-        setError(null);
+      );
+
+      if (requestId !== dataRequestIdRef.current) {
+        return;
       }
+
+      setFullData(data);
+      setFilteredData(data);
+      setError(null);
     } catch (error) {
+      if (requestId !== dataRequestIdRef.current) {
+        return;
+      }
+
       console.error("Error fetching data:", error);
-      setError("Failed to fetch college predictions. Please try again.");
+      if (error.status === 429) {
+        setError("Rate limit exceeded. Please try again later.");
+      } else {
+        setError(
+          error.message ||
+            "Failed to fetch college predictions. Please try again."
+        );
+      }
+      setFullData([]);
       setFilteredData([]);
     } finally {
-      setIsLoading(false);
+      if (requestId === dataRequestIdRef.current) {
+        setIsLoading(false);
+        setRequestRetryNotice("");
+      }
     }
   };
 
@@ -355,7 +390,10 @@ const CollegePredictor = () => {
     setCurrentExam(queryObject.exam);
     setPrimaryInputError("");
     if (queryObject.exam === "JoSAA") {
-      if (queryObject.rankMode === "estimate" || queryObject.rankMode === "known") {
+      if (
+        queryObject.rankMode === "estimate" ||
+        queryObject.rankMode === "known"
+      ) {
         setRankMode(queryObject.rankMode);
       } else {
         const hasAdvanced =
@@ -500,24 +538,42 @@ const CollegePredictor = () => {
 
     setIsEstimating(true);
     setEstimateError("");
+    setEstimateRetryNotice("");
+    const requestId = ++estimateRequestIdRef.current;
     try {
-      const response = await fetch("/api/jee-predict", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          marks: estimateInputType === "marks" ? Number(marksInput) : undefined,
-          percentile:
-            estimateInputType === "percentile"
-              ? Number(percentileInput)
-              : undefined,
-          category: queryObject.category,
-        }),
-      });
+      const { data } = await fetchJsonWithRetry(
+        "/api/jee-predict",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            marks:
+              estimateInputType === "marks" ? Number(marksInput) : undefined,
+            percentile:
+              estimateInputType === "percentile"
+                ? Number(percentileInput)
+                : undefined,
+            category: queryObject.category,
+          }),
+        },
+        {
+          ...estimateRetryOptions,
+          onRetry: ({ attempt, maxRetries, delayMs }) => {
+            if (requestId !== estimateRequestIdRef.current) return;
 
-      const data = await response.json();
-      if (!response.ok) {
-        setEstimateError(data.error || "Unable to estimate rank.");
-        setIsEstimating(false);
+            setEstimateRetryNotice(
+              createRetryMessage({
+                attempt,
+                maxRetries,
+                delayMs,
+                resourceLabel: "Estimating rank",
+              })
+            );
+          },
+        }
+      );
+
+      if (requestId !== estimateRequestIdRef.current) {
         return;
       }
 
@@ -535,9 +591,16 @@ const CollegePredictor = () => {
       setQueryObject(newQueryObject);
       debouncedRouterPush(newQueryObject);
     } catch (error) {
-      setEstimateError("Unable to estimate rank right now.");
+      if (requestId !== estimateRequestIdRef.current) {
+        return;
+      }
+
+      setEstimateError(error.message || "Unable to estimate rank right now.");
     } finally {
-      setIsEstimating(false);
+      if (requestId === estimateRequestIdRef.current) {
+        setIsEstimating(false);
+        setEstimateRetryNotice("");
+      }
     }
   };
 
@@ -570,9 +633,7 @@ const CollegePredictor = () => {
     const selectionCards = examConfig.fields
       .filter(
         (field) =>
-          !(
-            queryObject.exam === "JoSAA" && field.name === "qualifiedJeeAdv"
-          )
+          !(queryObject.exam === "JoSAA" && field.name === "qualifiedJeeAdv")
       )
       .map((field) => {
         const showHomeStateNote =
@@ -601,7 +662,7 @@ const CollegePredictor = () => {
 
     const primaryInputCard =
       queryObject.exam !== "JoSAA" && queryObject.exam !== "TNEA"
-          ? renderSelectionCard(
+        ? renderSelectionCard(
             "rank",
             getPrimaryInputConfig(queryObject.exam).label,
             <>
@@ -633,12 +694,12 @@ const CollegePredictor = () => {
                     ? "border-red-500 focus:border-red-500"
                     : "border-[#d8c7c1] focus:border-[#b52326]"
                 }`}
-                placeholder={getPrimaryInputConfig(queryObject.exam).placeholder}
+                placeholder={
+                  getPrimaryInputConfig(queryObject.exam).placeholder
+                }
               />
               {primaryInputError && (
-                <p className="mt-2 text-sm text-red-500">
-                  {primaryInputError}
-                </p>
+                <p className="mt-2 text-sm text-red-500">{primaryInputError}</p>
               )}
             </>,
             getPrimaryInputConfig(queryObject.exam).helperText
@@ -686,10 +747,10 @@ const CollegePredictor = () => {
                 </div>
               )}
 
-            {rankMode === "known" &&
-              examConfig.fields.find(
-                (field) => field.name === "qualifiedJeeAdv"
-              ) && (
+              {rankMode === "known" &&
+                examConfig.fields.find(
+                  (field) => field.name === "qualifiedJeeAdv"
+                ) &&
                 renderSelectionCard(
                   "qualifiedJeeAdv",
                   examConfig.fields.find(
@@ -707,215 +768,219 @@ const CollegePredictor = () => {
                     selectedValue={queryObject.qualifiedJeeAdv}
                     onChange={handleQueryObjectChange("qualifiedJeeAdv")}
                   />
-                )
-              )}
+                )}
 
-            {rankMode === "estimate" ? (
-              renderSelectionCard(
-                "estimate",
-                estimateInputType === "marks"
-                  ? examConfig.estimateMarksInput?.label ||
-                    "Enter JEE Main marks out of 300"
-                  : examConfig.estimatePercentileInput?.label ||
-                    "Enter JEE Main percentile",
-                <div className="flex flex-col gap-3">
-                  <div className="flex w-full justify-center">
-                    <div className="inline-flex w-full overflow-hidden rounded-xl border border-[#d8c7c1]">
-                      <button
-                        type="button"
-                        onClick={() => handleEstimateInputTypeChange("marks")}
-                        className={`flex-1 px-4 py-2 text-sm ${
-                          estimateInputType === "marks"
-                            ? "bg-[#B52326] text-white"
-                            : "bg-white text-gray-700"
-                        }`}
-                      >
-                        Marks
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() =>
-                          handleEstimateInputTypeChange("percentile")
-                        }
-                        className={`flex-1 px-4 py-2 text-sm ${
-                          estimateInputType === "percentile"
-                            ? "bg-[#B52326] text-white"
-                            : "bg-white text-gray-700"
-                        }`}
-                      >
-                        Percentile
-                      </button>
-                    </div>
-                  </div>
-                  {estimateInputType === "marks" ? (
-                    <>
-                      <input
-                        type="number"
-                        step="1"
-                        min="0"
-                        max="300"
-                        value={marksInput}
-                        onChange={handleMarksChange}
-                        onKeyDown={(e) => {
-                          if (
-                            [".", "e", "E", "+", "-", " "].includes(e.key)
-                          ) {
-                            e.preventDefault();
-                          }
-                        }}
-                        className={`w-full rounded-xl border bg-[#fffdfa] px-4 py-3 text-center outline-none transition focus:ring-2 focus:ring-[#f4d5d6] ${
-                          marksError
-                            ? "border-red-500 focus:border-red-500"
-                            : "border-[#d8c7c1] focus:border-[#b52326]"
-                        }`}
-                        placeholder={
-                          examConfig.estimateMarksInput?.placeholder ||
-                          "e.g., 182"
-                        }
-                      />
-                      {marksError && (
-                        <p className="text-sm text-red-500">{marksError}</p>
+              {rankMode === "estimate"
+                ? renderSelectionCard(
+                    "estimate",
+                    estimateInputType === "marks"
+                      ? examConfig.estimateMarksInput?.label ||
+                          "Enter JEE Main marks out of 300"
+                      : examConfig.estimatePercentileInput?.label ||
+                          "Enter JEE Main percentile",
+                    <div className="flex flex-col gap-3">
+                      <div className="flex w-full justify-center">
+                        <div className="inline-flex w-full overflow-hidden rounded-xl border border-[#d8c7c1]">
+                          <button
+                            type="button"
+                            onClick={() =>
+                              handleEstimateInputTypeChange("marks")
+                            }
+                            className={`flex-1 px-4 py-2 text-sm ${
+                              estimateInputType === "marks"
+                                ? "bg-[#B52326] text-white"
+                                : "bg-white text-gray-700"
+                            }`}
+                          >
+                            Marks
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() =>
+                              handleEstimateInputTypeChange("percentile")
+                            }
+                            className={`flex-1 px-4 py-2 text-sm ${
+                              estimateInputType === "percentile"
+                                ? "bg-[#B52326] text-white"
+                                : "bg-white text-gray-700"
+                            }`}
+                          >
+                            Percentile
+                          </button>
+                        </div>
+                      </div>
+                      {estimateInputType === "marks" ? (
+                        <>
+                          <input
+                            type="number"
+                            step="1"
+                            min="0"
+                            max="300"
+                            value={marksInput}
+                            onChange={handleMarksChange}
+                            onKeyDown={(e) => {
+                              if (
+                                [".", "e", "E", "+", "-", " "].includes(e.key)
+                              ) {
+                                e.preventDefault();
+                              }
+                            }}
+                            className={`w-full rounded-xl border bg-[#fffdfa] px-4 py-3 text-center outline-none transition focus:ring-2 focus:ring-[#f4d5d6] ${
+                              marksError
+                                ? "border-red-500 focus:border-red-500"
+                                : "border-[#d8c7c1] focus:border-[#b52326]"
+                            }`}
+                            placeholder={
+                              examConfig.estimateMarksInput?.placeholder ||
+                              "e.g., 182"
+                            }
+                          />
+                          {marksError && (
+                            <p className="text-sm text-red-500">{marksError}</p>
+                          )}
+                        </>
+                      ) : (
+                        <>
+                          <input
+                            type="number"
+                            step="0.01"
+                            min="0"
+                            max="100"
+                            value={percentileInput}
+                            onChange={handlePercentileChange}
+                            onKeyDown={(e) => {
+                              if (["e", "E", "+", "-", " "].includes(e.key)) {
+                                e.preventDefault();
+                              }
+                            }}
+                            className={`w-full rounded-xl border bg-[#fffdfa] px-4 py-3 text-center outline-none transition focus:ring-2 focus:ring-[#f4d5d6] ${
+                              percentileError
+                                ? "border-red-500 focus:border-red-500"
+                                : "border-[#d8c7c1] focus:border-[#b52326]"
+                            }`}
+                            placeholder={
+                              examConfig.estimatePercentileInput?.placeholder ||
+                              "e.g., 97.45"
+                            }
+                          />
+                          {percentileError && (
+                            <p className="text-sm text-red-500">
+                              {percentileError}
+                            </p>
+                          )}
+                        </>
                       )}
-                    </>
-                  ) : (
-                    <>
-                      <input
-                        type="number"
-                        step="0.01"
-                        min="0"
-                        max="100"
-                        value={percentileInput}
-                        onChange={handlePercentileChange}
-                        onKeyDown={(e) => {
-                          if (["e", "E", "+", "-", " "].includes(e.key)) {
-                            e.preventDefault();
-                          }
-                        }}
-                        className={`w-full rounded-xl border bg-[#fffdfa] px-4 py-3 text-center outline-none transition focus:ring-2 focus:ring-[#f4d5d6] ${
-                          percentileError
-                            ? "border-red-500 focus:border-red-500"
-                            : "border-[#d8c7c1] focus:border-[#b52326]"
-                        }`}
-                        placeholder={
-                          examConfig.estimatePercentileInput?.placeholder ||
-                          "e.g., 97.45"
+                      <button
+                        type="button"
+                        onClick={handleEstimateRank}
+                        disabled={
+                          isEstimating ||
+                          (estimateInputType === "marks"
+                            ? marksInput === "" || !!marksError
+                            : percentileInput === "" || !!percentileError) ||
+                          !queryObject.category
                         }
-                      />
-                      {percentileError && (
-                        <p className="text-sm text-red-500">
-                          {percentileError}
+                        className="w-full rounded-lg bg-[#B52326] px-4 py-2 text-white hover:bg-[#9E1F22] disabled:bg-gray-300 disabled:text-gray-600"
+                      >
+                        {isEstimating ? "Estimating..." : "Estimate Rank"}
+                      </button>
+                      {estimateError && (
+                        <p className="text-sm text-red-500">{estimateError}</p>
+                      )}
+                      {estimateRetryNotice && (
+                        <p className="text-sm text-[#8f2e31]">
+                          {estimateRetryNotice}
                         </p>
                       )}
-                    </>
-                  )}
-                  <button
-                    type="button"
-                    onClick={handleEstimateRank}
-                    disabled={
-                      isEstimating ||
-                      (estimateInputType === "marks"
-                        ? marksInput === "" || !!marksError
-                        : percentileInput === "" || !!percentileError) ||
-                      !queryObject.category
-                    }
-                    className="w-full rounded-lg bg-[#B52326] px-4 py-2 text-white hover:bg-[#9E1F22] disabled:bg-gray-300 disabled:text-gray-600"
-                  >
-                    {isEstimating ? "Estimating..." : "Estimate Rank"}
-                  </button>
-                  {estimateError && (
-                    <p className="text-sm text-red-500">{estimateError}</p>
-                  )}
-                </div>,
-                estimatedRank && estimatedPercentile !== null ? (
-                  <>
-                    Predicted percentile:{" "}
-                    <strong>{estimatedPercentile}</strong>. Predicted category
-                    rank: <strong>{estimatedRank}</strong>.
-                  </>
-                ) : null
-              )
-            ) : (
-              renderSelectionCard(
-                "mainRank",
-                examConfig.primaryInput?.label ||
-                  "Enter JEE Main Category Rank",
-                <input
-                  type="number"
-                  step={examConfig.primaryInput?.step || "1"}
-                  min={examConfig.primaryInput?.min || "0"}
-                  value={
-                    queryObject.mainRank !== undefined
-                      ? normalizePrimaryInputValue(
-                          "JoSAA",
-                          String(queryObject.mainRank)
-                        )
-                      : queryObject.rank
-                      ? normalizePrimaryInputValue(
-                          "JoSAA",
-                          String(queryObject.rank)
-                        )
-                      : ""
-                  }
-                  onChange={(e) => {
-                    const value = normalizePrimaryInputValue(
-                      "JoSAA",
-                      e.target.value
-                    );
-                    const newQueryObject = {
-                      ...queryObject,
-                      mainRank: value,
-                      rank: value,
-                    };
-                    setQueryObject(newQueryObject);
-                    debouncedRouterPush(newQueryObject);
-                  }}
-                  onKeyDown={(e) => {
-                    if ([".", "e", "E", "+", "-"].includes(e.key)) {
-                      e.preventDefault();
-                    }
-                  }}
-                  className="w-full rounded-xl border border-[#d8c7c1] bg-[#fffdfa] px-4 py-3 text-center outline-none transition focus:border-[#b52326] focus:ring-2 focus:ring-[#f4d5d6]"
-                  placeholder={
-                    examConfig.primaryInput?.placeholder ||
-                    "Enter JEE Main category rank"
-                  }
-                />
-              )
-            )}
-
-            {rankMode === "known" && queryObject.qualifiedJeeAdv === "Yes" && (
-              renderSelectionCard(
-                "advRank",
-                examConfig.advancedInput?.label ||
-                  "Enter JEE Advanced Category Rank",
-                <>
-                  <input
-                    type="string"
-                    step="1"
-                    value={queryObject.advRank || ""}
-                    onChange={handleJeeAdvancedRankChange}
-                    onKeyDown={(e) => {
-                      if ([".", "e", "E", "+", "-", " "].includes(e.key)) {
-                        e.preventDefault();
+                    </div>,
+                    estimatedRank && estimatedPercentile !== null ? (
+                      <>
+                        Predicted percentile:{" "}
+                        <strong>{estimatedPercentile}</strong>. Predicted
+                        category rank: <strong>{estimatedRank}</strong>.
+                      </>
+                    ) : null
+                  )
+                : renderSelectionCard(
+                    "mainRank",
+                    examConfig.primaryInput?.label ||
+                      "Enter JEE Main Category Rank",
+                    <input
+                      type="number"
+                      step={examConfig.primaryInput?.step || "1"}
+                      min={examConfig.primaryInput?.min || "0"}
+                      value={
+                        queryObject.mainRank !== undefined
+                          ? normalizePrimaryInputValue(
+                              "JoSAA",
+                              String(queryObject.mainRank)
+                            )
+                          : queryObject.rank
+                            ? normalizePrimaryInputValue(
+                                "JoSAA",
+                                String(queryObject.rank)
+                              )
+                            : ""
                       }
-                    }}
-                    className={`w-full rounded-xl border bg-[#fffdfa] px-4 py-3 text-center outline-none transition focus:ring-2 focus:ring-[#f4d5d6] ${
-                      rankError
-                        ? "border-red-500 focus:border-red-500"
-                        : "border-[#d8c7c1] focus:border-[#b52326]"
-                    }`}
-                    placeholder={
-                      examConfig.advancedInput?.placeholder ||
-                      "e.g., 104 or 104P"
-                    }
-                  />
-                  {rankError && (
-                    <p className="mt-2 text-sm text-red-500">{rankError}</p>
+                      onChange={(e) => {
+                        const value = normalizePrimaryInputValue(
+                          "JoSAA",
+                          e.target.value
+                        );
+                        const newQueryObject = {
+                          ...queryObject,
+                          mainRank: value,
+                          rank: value,
+                        };
+                        setQueryObject(newQueryObject);
+                        debouncedRouterPush(newQueryObject);
+                      }}
+                      onKeyDown={(e) => {
+                        if ([".", "e", "E", "+", "-"].includes(e.key)) {
+                          e.preventDefault();
+                        }
+                      }}
+                      className="w-full rounded-xl border border-[#d8c7c1] bg-[#fffdfa] px-4 py-3 text-center outline-none transition focus:border-[#b52326] focus:ring-2 focus:ring-[#f4d5d6]"
+                      placeholder={
+                        examConfig.primaryInput?.placeholder ||
+                        "Enter JEE Main category rank"
+                      }
+                    />
                   )}
-                </>,
-                "You can enter a plain rank like 104 or use a P suffix like 104P for PwD."
-              )
-            )}
+
+              {rankMode === "known" &&
+                queryObject.qualifiedJeeAdv === "Yes" &&
+                renderSelectionCard(
+                  "advRank",
+                  examConfig.advancedInput?.label ||
+                    "Enter JEE Advanced Category Rank",
+                  <>
+                    <input
+                      type="string"
+                      step="1"
+                      value={queryObject.advRank || ""}
+                      onChange={handleJeeAdvancedRankChange}
+                      onKeyDown={(e) => {
+                        if ([".", "e", "E", "+", "-", " "].includes(e.key)) {
+                          e.preventDefault();
+                        }
+                      }}
+                      className={`w-full rounded-xl border bg-[#fffdfa] px-4 py-3 text-center outline-none transition focus:ring-2 focus:ring-[#f4d5d6] ${
+                        rankError
+                          ? "border-red-500 focus:border-red-500"
+                          : "border-[#d8c7c1] focus:border-[#b52326]"
+                      }`}
+                      placeholder={
+                        examConfig.advancedInput?.placeholder ||
+                        "e.g., 104 or 104P"
+                      }
+                    />
+                    {rankError && (
+                      <p className="mt-2 text-sm text-red-500">{rankError}</p>
+                    )}
+                  </>,
+                  "You can enter a plain rank like 104 or use a P suffix like 104P for PwD."
+                )}
             </div>
           </>
         )}
@@ -955,7 +1020,7 @@ const CollegePredictor = () => {
       })
       .filter(Boolean);
 
-      if (queryObject.exam === "JoSAA") {
+    if (queryObject.exam === "JoSAA") {
       if (rankMode === "estimate" && estimatedRank) {
         summaryItems.push({
           key: "predictedRank",
@@ -1069,6 +1134,11 @@ const CollegePredictor = () => {
           {isLoading ? (
             <div className="text-center py-10">
               <p className="text-xl text-[#8f2e31]">Loading predictions...</p>
+              {requestRetryNotice && (
+                <p className="mt-3 text-sm text-[#8f2e31]">
+                  {requestRetryNotice}
+                </p>
+              )}
             </div>
           ) : error ? (
             <div className="text-center py-10 px-4">

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useRef, useState } from "react";
 import Script from "next/script";
 import getConstants from "../constants";
 import examConfigs from "../examConfig";
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import Head from "next/head";
 import dynamic from "next/dynamic";
 import TneaScoreCalculator from "../components/TneaScoreCalculator";
+import { createRetryMessage, fetchJsonWithRetry } from "../utils/apiClient";
 
 // Dynamically import Dropdown with SSR disabled
 const Dropdown = dynamic(() => import("../components/dropdown"), {
@@ -37,17 +38,11 @@ const validatePrimaryInputValue = (exam, value) => {
     return "Please enter a valid value.";
   }
 
-  if (
-    inputConfig.min !== undefined &&
-    numericValue < Number(inputConfig.min)
-  ) {
+  if (inputConfig.min !== undefined && numericValue < Number(inputConfig.min)) {
     return rangeMessage;
   }
 
-  if (
-    inputConfig.max !== undefined &&
-    numericValue > Number(inputConfig.max)
-  ) {
+  if (inputConfig.max !== undefined && numericValue > Number(inputConfig.max)) {
     return rangeMessage;
   }
 
@@ -67,7 +62,16 @@ const normalizePrimaryInputValue = (exam, value) => {
 };
 
 const getCleanQueryEntries = (data) =>
-  Object.entries(data).filter(([, value]) => value !== undefined && value !== null && value !== "");
+  Object.entries(data).filter(
+    ([, value]) => value !== undefined && value !== null && value !== ""
+  );
+
+const estimateRetryOptions = {
+  maxRetries: 2,
+  initialDelayMs: 400,
+  maxDelayMs: 2000,
+  safeToRetry: true,
+};
 
 const ExamForm = () => {
   const [selectedExam, setSelectedExam] = useState("");
@@ -82,9 +86,11 @@ const ExamForm = () => {
   const [percentileError, setPercentileError] = useState("");
   const [estimateInputType, setEstimateInputType] = useState("marks");
   const [estimateError, setEstimateError] = useState("");
+  const [estimateRetryNotice, setEstimateRetryNotice] = useState("");
   const [estimatedRank, setEstimatedRank] = useState(null);
   const [estimatedPercentile, setEstimatedPercentile] = useState(null);
   const [isEstimating, setIsEstimating] = useState(false);
+  const estimateRequestIdRef = useRef(0);
   const router = useRouter();
 
   const handleExamChange = (selectedOption) => {
@@ -261,24 +267,42 @@ const ExamForm = () => {
 
     setIsEstimating(true);
     setEstimateError("");
+    setEstimateRetryNotice("");
+    const requestId = ++estimateRequestIdRef.current;
     try {
-      const response = await fetch("/api/jee-predict", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          marks: estimateInputType === "marks" ? Number(marksInput) : undefined,
-          percentile:
-            estimateInputType === "percentile"
-              ? Number(percentileInput)
-              : undefined,
-          category: formData.category,
-        }),
-      });
+      const { data } = await fetchJsonWithRetry(
+        "/api/jee-predict",
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            marks:
+              estimateInputType === "marks" ? Number(marksInput) : undefined,
+            percentile:
+              estimateInputType === "percentile"
+                ? Number(percentileInput)
+                : undefined,
+            category: formData.category,
+          }),
+        },
+        {
+          ...estimateRetryOptions,
+          onRetry: ({ attempt, maxRetries, delayMs }) => {
+            if (requestId !== estimateRequestIdRef.current) return;
 
-      const data = await response.json();
-      if (!response.ok) {
-        setEstimateError(data.error || "Unable to estimate rank.");
-        setIsEstimating(false);
+            setEstimateRetryNotice(
+              createRetryMessage({
+                attempt,
+                maxRetries,
+                delayMs,
+                resourceLabel: "Estimating rank",
+              })
+            );
+          },
+        }
+      );
+
+      if (requestId !== estimateRequestIdRef.current) {
         return;
       }
 
@@ -295,9 +319,16 @@ const ExamForm = () => {
         return nextData;
       });
     } catch (error) {
-      setEstimateError("Unable to estimate rank right now.");
+      if (requestId !== estimateRequestIdRef.current) {
+        return;
+      }
+
+      setEstimateError(error.message || "Unable to estimate rank right now.");
     } finally {
-      setIsEstimating(false);
+      if (requestId === estimateRequestIdRef.current) {
+        setIsEstimating(false);
+        setEstimateRetryNotice("");
+      }
     }
   };
 
@@ -498,9 +529,7 @@ const ExamForm = () => {
     return fieldsToRender.map((field) =>
       renderFormCard(
         field.name,
-        typeof field.label === "function"
-          ? field.label(formData)
-          : field.label,
+        typeof field.label === "function" ? field.label(formData) : field.label,
         <Dropdown
           options={field.options.map((option) =>
             typeof option === "string"
@@ -581,7 +610,7 @@ const ExamForm = () => {
               ) : (
                 selectedExam && (
                   <>
-                    {selectedExam === "JoSAA" && (
+                    {selectedExam === "JoSAA" &&
                       renderFormCard(
                         "rankMode",
                         "Do you want rank prediction?",
@@ -614,260 +643,260 @@ const ExamForm = () => {
                         null,
                         null,
                         true
-                      )
-                    )}
+                      )}
 
                     {selectedExam === "JoSAA" &&
                       rankMode === "known" &&
                       config?.fields?.find(
                         (field) => field.name === "qualifiedJeeAdv"
-                      ) && (
-                        renderFormCard(
-                          "qualifiedJeeAdv",
-                          config.fields.find(
-                            (field) => field.name === "qualifiedJeeAdv"
-                          ).label,
-                          <Dropdown
-                            options={config.fields
-                              .find((field) => field.name === "qualifiedJeeAdv")
-                              .options.map((option) =>
-                                typeof option === "string"
-                                  ? { value: option, label: option }
-                                  : option
-                              )}
-                            onChange={handleInputChange("qualifiedJeeAdv")}
-                            className="w-full"
-                            selectedValue={formData.qualifiedJeeAdv}
-                          />
-                        )
+                      ) &&
+                      renderFormCard(
+                        "qualifiedJeeAdv",
+                        config.fields.find(
+                          (field) => field.name === "qualifiedJeeAdv"
+                        ).label,
+                        <Dropdown
+                          options={config.fields
+                            .find((field) => field.name === "qualifiedJeeAdv")
+                            .options.map((option) =>
+                              typeof option === "string"
+                                ? { value: option, label: option }
+                                : option
+                            )}
+                          onChange={handleInputChange("qualifiedJeeAdv")}
+                          className="w-full"
+                          selectedValue={formData.qualifiedJeeAdv}
+                        />
                       )}
 
-                    {selectedExam === "JoSAA" && rankMode === "estimate" ? (
-                      renderFormCard(
-                        "estimate",
-                        estimateInputType === "marks"
-                          ? config?.estimateMarksInput?.label ||
-                            "Enter JEE Main marks out of 300"
-                          : config?.estimatePercentileInput?.label ||
-                            "Enter JEE Main percentile",
-                        <div className="flex flex-col gap-2.5">
-                          <div className="flex justify-center w-full">
-                            <div className="inline-flex w-full overflow-hidden rounded-xl border border-[#d8c7c1]">
-                              <button
-                                type="button"
-                                onClick={() =>
-                                  handleEstimateInputTypeChange("marks")
-                                }
-                                className={`flex-1 px-4 py-2 text-sm ${
-                                  estimateInputType === "marks"
-                                    ? "bg-[#B52326] text-white"
-                                    : "bg-white text-gray-700"
-                                }`}
-                              >
-                                Marks
-                              </button>
-                              <button
-                                type="button"
-                                onClick={() =>
-                                  handleEstimateInputTypeChange("percentile")
-                                }
-                                className={`flex-1 px-4 py-2 text-sm ${
-                                  estimateInputType === "percentile"
-                                    ? "bg-[#B52326] text-white"
-                                    : "bg-white text-gray-700"
-                                }`}
-                              >
-                                Percentile
-                              </button>
-                            </div>
-                          </div>
-                          {estimateInputType === "marks" ? (
-                            <>
-                              <input
-                                type="number"
-                                step="1"
-                                min="0"
-                                max="300"
-                                value={marksInput}
-                                onChange={handleMarksChange}
-                                onKeyDown={(e) => {
-                                  if (
-                                    [".", "e", "E", "+", "-", " "].includes(
-                                      e.key
-                                    )
-                                  ) {
-                                    e.preventDefault();
+                    {selectedExam === "JoSAA" && rankMode === "estimate"
+                      ? renderFormCard(
+                          "estimate",
+                          estimateInputType === "marks"
+                            ? config?.estimateMarksInput?.label ||
+                                "Enter JEE Main marks out of 300"
+                            : config?.estimatePercentileInput?.label ||
+                                "Enter JEE Main percentile",
+                          <div className="flex flex-col gap-2.5">
+                            <div className="flex justify-center w-full">
+                              <div className="inline-flex w-full overflow-hidden rounded-xl border border-[#d8c7c1]">
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    handleEstimateInputTypeChange("marks")
                                   }
-                                }}
-                                className={`w-full rounded-xl border bg-[#fffdfa] p-3 text-center outline-none transition focus:ring-2 focus:ring-[#f4d5d6] ${
-                                  marksError
-                                    ? "border-red-500 focus:border-red-500"
-                                    : "border-[#d8c7c1] focus:border-[#b52326]"
-                                }`}
-                                placeholder={
-                                  config?.estimateMarksInput?.placeholder ||
-                                  "e.g., 182"
-                                }
-                              />
-                              {marksError && (
-                                <p className="text-red-500 text-sm">
-                                  {marksError}
-                                </p>
-                              )}
-                            </>
-                          ) : (
-                            <>
-                              <input
-                                type="number"
-                                step="0.01"
-                                min="0"
-                                max="100"
-                                value={percentileInput}
-                                onChange={handlePercentileChange}
-                                onKeyDown={(e) => {
-                                  if (
-                                    ["e", "E", "+", "-", " "].includes(e.key)
-                                  ) {
-                                    e.preventDefault();
+                                  className={`flex-1 px-4 py-2 text-sm ${
+                                    estimateInputType === "marks"
+                                      ? "bg-[#B52326] text-white"
+                                      : "bg-white text-gray-700"
+                                  }`}
+                                >
+                                  Marks
+                                </button>
+                                <button
+                                  type="button"
+                                  onClick={() =>
+                                    handleEstimateInputTypeChange("percentile")
                                   }
-                                }}
-                                className={`w-full rounded-xl border bg-[#fffdfa] p-3 text-center outline-none transition focus:ring-2 focus:ring-[#f4d5d6] ${
-                                  percentileError
-                                    ? "border-red-500 focus:border-red-500"
-                                    : "border-[#d8c7c1] focus:border-[#b52326]"
-                                }`}
-                                placeholder={
-                                  config?.estimatePercentileInput
-                                    ?.placeholder || "e.g., 97.45"
-                                }
-                              />
-                              {percentileError && (
-                                <p className="text-red-500 text-sm">
-                                  {percentileError}
-                                </p>
-                              )}
-                            </>
-                          )}
-                          <button
-                            type="button"
-                            onClick={handleEstimateRank}
-                            disabled={
-                              isEstimating ||
-                              (estimateInputType === "marks"
-                                ? marksInput === "" || !!marksError
-                                : percentileInput === "" ||
-                                  !!percentileError) ||
-                              !formData.category
-                            }
-                            className="rounded-lg bg-[#B52326] px-4 py-2 text-white hover:bg-[#9E1F22] disabled:bg-gray-300 disabled:text-gray-600"
-                          >
-                            {isEstimating ? "Estimating..." : "Estimate Rank"}
-                          </button>
-                          {estimateError && (
-                            <p className="text-red-500 text-sm">
-                              {estimateError}
-                            </p>
-                          )}
-                          {estimatedRank && estimatedPercentile !== null && (
-                            <div className="rounded-xl border border-[#eaded8] bg-[#fffdfa] p-4 text-left text-sm text-gray-700">
-                              <p>
-                                Predicted Percentile:{" "}
-                                <strong>{estimatedPercentile}</strong>
-                              </p>
-                              <p>
-                                Predicted Category Rank:{" "}
-                                <strong>{estimatedRank}</strong>
-                              </p>
-                              <p className="text-xs text-gray-500 mt-1">
-                                Results are based on average data of 10k+
-                                students from 2024 and 2025. Actual 2025/26
-                                results may vary depending on the paper slot.
-                              </p>
+                                  className={`flex-1 px-4 py-2 text-sm ${
+                                    estimateInputType === "percentile"
+                                      ? "bg-[#B52326] text-white"
+                                      : "bg-white text-gray-700"
+                                  }`}
+                                >
+                                  Percentile
+                                </button>
+                              </div>
                             </div>
-                          )}
-                        </div>,
-                        null,
-                        null,
-                        true
-                      )
-                    ) : (
-                      renderFormCard(
-                        "primaryInput",
-                        getPrimaryInputConfig(selectedExam).label,
-                        <input
-                          type="number"
-                          step={getPrimaryInputConfig(selectedExam).step}
-                          min={getPrimaryInputConfig(selectedExam).min}
-                          max={getPrimaryInputConfig(selectedExam).max}
-                          value={
-                            selectedExam === "JoSAA"
-                              ? formData.mainRank || ""
-                              : formData.rank || ""
-                          }
-                          onChange={handleRankChange}
-                          onKeyDown={(e) => {
-                            if (
-                              ["e", "E", "+", "-", " "].includes(e.key) ||
-                              (!getPrimaryInputConfig(selectedExam)
-                                .allowDecimal &&
-                                e.key === ".")
-                            ) {
-                              e.preventDefault();
+                            {estimateInputType === "marks" ? (
+                              <>
+                                <input
+                                  type="number"
+                                  step="1"
+                                  min="0"
+                                  max="300"
+                                  value={marksInput}
+                                  onChange={handleMarksChange}
+                                  onKeyDown={(e) => {
+                                    if (
+                                      [".", "e", "E", "+", "-", " "].includes(
+                                        e.key
+                                      )
+                                    ) {
+                                      e.preventDefault();
+                                    }
+                                  }}
+                                  className={`w-full rounded-xl border bg-[#fffdfa] p-3 text-center outline-none transition focus:ring-2 focus:ring-[#f4d5d6] ${
+                                    marksError
+                                      ? "border-red-500 focus:border-red-500"
+                                      : "border-[#d8c7c1] focus:border-[#b52326]"
+                                  }`}
+                                  placeholder={
+                                    config?.estimateMarksInput?.placeholder ||
+                                    "e.g., 182"
+                                  }
+                                />
+                                {marksError && (
+                                  <p className="text-red-500 text-sm">
+                                    {marksError}
+                                  </p>
+                                )}
+                              </>
+                            ) : (
+                              <>
+                                <input
+                                  type="number"
+                                  step="0.01"
+                                  min="0"
+                                  max="100"
+                                  value={percentileInput}
+                                  onChange={handlePercentileChange}
+                                  onKeyDown={(e) => {
+                                    if (
+                                      ["e", "E", "+", "-", " "].includes(e.key)
+                                    ) {
+                                      e.preventDefault();
+                                    }
+                                  }}
+                                  className={`w-full rounded-xl border bg-[#fffdfa] p-3 text-center outline-none transition focus:ring-2 focus:ring-[#f4d5d6] ${
+                                    percentileError
+                                      ? "border-red-500 focus:border-red-500"
+                                      : "border-[#d8c7c1] focus:border-[#b52326]"
+                                  }`}
+                                  placeholder={
+                                    config?.estimatePercentileInput
+                                      ?.placeholder || "e.g., 97.45"
+                                  }
+                                />
+                                {percentileError && (
+                                  <p className="text-red-500 text-sm">
+                                    {percentileError}
+                                  </p>
+                                )}
+                              </>
+                            )}
+                            <button
+                              type="button"
+                              onClick={handleEstimateRank}
+                              disabled={
+                                isEstimating ||
+                                (estimateInputType === "marks"
+                                  ? marksInput === "" || !!marksError
+                                  : percentileInput === "" ||
+                                    !!percentileError) ||
+                                !formData.category
+                              }
+                              className="rounded-lg bg-[#B52326] px-4 py-2 text-white hover:bg-[#9E1F22] disabled:bg-gray-300 disabled:text-gray-600"
+                            >
+                              {isEstimating ? "Estimating..." : "Estimate Rank"}
+                            </button>
+                            {estimateError && (
+                              <p className="text-red-500 text-sm">
+                                {estimateError}
+                              </p>
+                            )}
+                            {estimateRetryNotice && (
+                              <p className="text-[#8f2e31] text-sm">
+                                {estimateRetryNotice}
+                              </p>
+                            )}
+                            {estimatedRank && estimatedPercentile !== null && (
+                              <div className="rounded-xl border border-[#eaded8] bg-[#fffdfa] p-4 text-left text-sm text-gray-700">
+                                <p>
+                                  Predicted Percentile:{" "}
+                                  <strong>{estimatedPercentile}</strong>
+                                </p>
+                                <p>
+                                  Predicted Category Rank:{" "}
+                                  <strong>{estimatedRank}</strong>
+                                </p>
+                                <p className="text-xs text-gray-500 mt-1">
+                                  Results are based on average data of 10k+
+                                  students from 2024 and 2025. Actual 2025/26
+                                  results may vary depending on the paper slot.
+                                </p>
+                              </div>
+                            )}
+                          </div>,
+                          null,
+                          null,
+                          true
+                        )
+                      : renderFormCard(
+                          "primaryInput",
+                          getPrimaryInputConfig(selectedExam).label,
+                          <input
+                            type="number"
+                            step={getPrimaryInputConfig(selectedExam).step}
+                            min={getPrimaryInputConfig(selectedExam).min}
+                            max={getPrimaryInputConfig(selectedExam).max}
+                            value={
+                              selectedExam === "JoSAA"
+                                ? formData.mainRank || ""
+                                : formData.rank || ""
                             }
-                          }}
-                          className={`w-full rounded-xl border bg-white px-4 py-3 text-left text-sm outline-none transition focus:ring-2 focus:ring-[#f4d5d6] sm:text-base ${
-                            primaryInputError
-                              ? "border-red-500 focus:border-red-500"
-                              : "border-[#d8c7c1] focus:border-[#b52326]"
-                          }`}
-                          placeholder={
-                            getPrimaryInputConfig(selectedExam).placeholder
-                          }
-                        />,
-                        getPrimaryInputConfig(selectedExam).helperText,
-                        primaryInputError
-                      )
-                    )}
+                            onChange={handleRankChange}
+                            onKeyDown={(e) => {
+                              if (
+                                ["e", "E", "+", "-", " "].includes(e.key) ||
+                                (!getPrimaryInputConfig(selectedExam)
+                                  .allowDecimal &&
+                                  e.key === ".")
+                              ) {
+                                e.preventDefault();
+                              }
+                            }}
+                            className={`w-full rounded-xl border bg-white px-4 py-3 text-left text-sm outline-none transition focus:ring-2 focus:ring-[#f4d5d6] sm:text-base ${
+                              primaryInputError
+                                ? "border-red-500 focus:border-red-500"
+                                : "border-[#d8c7c1] focus:border-[#b52326]"
+                            }`}
+                            placeholder={
+                              getPrimaryInputConfig(selectedExam).placeholder
+                            }
+                          />,
+                          getPrimaryInputConfig(selectedExam).helperText,
+                          primaryInputError
+                        )}
 
                     {/* JEE Advanced Rank input field - only show if user selected Yes for qualifiedJeeAdv */}
                     {selectedExam === "JoSAA" &&
                       rankMode === "known" &&
-                      formData.qualifiedJeeAdv === "Yes" && (
-                        renderFormCard(
-                          "advRank",
-                          config?.advancedInput?.label ||
-                            "Enter JEE Advanced Category Rank",
-                          <div className="flex flex-col w-full">
-                            <input
-                              type="string"
-                              step="1"
-                              value={formData.advRank || ""}
-                              onChange={handleAdvancedRankChange}
-                              onKeyDown={(e) => {
-                                if (
-                                  [".", "e", "E", "+", "-", " "].includes(e.key)
-                                ) {
-                                  e.preventDefault();
-                                }
-                              }}
-                              className={`w-full rounded-xl border bg-[#fffdfa] p-3 text-center outline-none transition focus:ring-2 focus:ring-[#f4d5d6] ${
-                                rankError
-                                  ? "border-red-500 focus:border-red-500"
-                                  : "border-[#d8c7c1] focus:border-[#b52326]"
-                              }`}
-                              placeholder={
-                                config?.advancedInput?.placeholder ||
-                                "e.g., 104 or 104P"
+                      formData.qualifiedJeeAdv === "Yes" &&
+                      renderFormCard(
+                        "advRank",
+                        config?.advancedInput?.label ||
+                          "Enter JEE Advanced Category Rank",
+                        <div className="flex flex-col w-full">
+                          <input
+                            type="string"
+                            step="1"
+                            value={formData.advRank || ""}
+                            onChange={handleAdvancedRankChange}
+                            onKeyDown={(e) => {
+                              if (
+                                [".", "e", "E", "+", "-", " "].includes(e.key)
+                              ) {
+                                e.preventDefault();
                               }
-                            />
-                            <p className="text-xs text-gray-500 mt-2 leading-5">
-                              Enter rank (e.g., 104) or rank with 'P' suffix
-                              (e.g., 104P)
-                            </p>
-                          </div>,
-                          null,
-                          rankError
-                        )
+                            }}
+                            className={`w-full rounded-xl border bg-[#fffdfa] p-3 text-center outline-none transition focus:ring-2 focus:ring-[#f4d5d6] ${
+                              rankError
+                                ? "border-red-500 focus:border-red-500"
+                                : "border-[#d8c7c1] focus:border-[#b52326]"
+                            }`}
+                            placeholder={
+                              config?.advancedInput?.placeholder ||
+                              "e.g., 104 or 104P"
+                            }
+                          />
+                          <p className="text-xs text-gray-500 mt-2 leading-5">
+                            Enter rank (e.g., 104) or rank with 'P' suffix
+                            (e.g., 104P)
+                          </p>
+                        </div>,
+                        null,
+                        rankError
                       )}
                   </>
                 )
@@ -890,9 +919,9 @@ const ExamForm = () => {
                     (!formData.advRank || formData.advRank === "")
                       ? "Please enter your JEE Advanced rank."
                       : selectedExam === "JoSAA" &&
-                        (!formData.mainRank || formData.mainRank === "")
-                      ? "Please enter your JEE Main rank."
-                      : "Please fill all the required fields before submitting!"}
+                          (!formData.mainRank || formData.mainRank === "")
+                        ? "Please enter your JEE Main rank."
+                        : "Please fill all the required fields before submitting!"}
                   </p>
                 )}
               </div>

--- a/pages/scholarships.js
+++ b/pages/scholarships.js
@@ -1,13 +1,19 @@
 import Head from "next/head";
 import ScholarshipReferenceBrowser from "../components/ScholarshipReferenceBrowser";
 
+const scholarshipRetryOptions = {
+  maxRetries: 3,
+  initialDelayMs: 500,
+  maxDelayMs: 3000,
+};
+
 const ScholarshipsPage = () => {
   return (
     <>
       <Head>
         <title>Scholarships Reference - Home</title>
       </Head>
-      <ScholarshipReferenceBrowser />
+      <ScholarshipReferenceBrowser retryOptions={scholarshipRetryOptions} />
     </>
   );
 };

--- a/utils/apiClient.js
+++ b/utils/apiClient.js
@@ -1,0 +1,252 @@
+const DEFAULT_RETRYABLE_STATUSES = [408, 425, 500, 502, 503, 504];
+const DEFAULT_RETRYABLE_METHODS = ["GET", "HEAD", "OPTIONS"];
+
+export const DEFAULT_RETRY_OPTIONS = {
+  maxRetries: 3,
+  initialDelayMs: 400,
+  maxDelayMs: 3000,
+  backoffMultiplier: 2,
+  jitterRatio: 0.15,
+  retryableStatuses: DEFAULT_RETRYABLE_STATUSES,
+  retryableMethods: DEFAULT_RETRYABLE_METHODS,
+  safeToRetry: false,
+};
+
+const wait = (delayMs) =>
+  new Promise((resolve) => {
+    setTimeout(resolve, delayMs);
+  });
+
+const getRequestUrl = (input) => {
+  if (typeof input === "string") {
+    return input;
+  }
+
+  if (input instanceof URL) {
+    return input.toString();
+  }
+
+  return input?.url || "";
+};
+
+const normalizeMethod = (init) => (init?.method || "GET").toUpperCase();
+
+const getRetryAfterDelayMs = (response) => {
+  const retryAfterHeader = response.headers.get("retry-after");
+  if (!retryAfterHeader) {
+    return null;
+  }
+
+  const retryAfterSeconds = Number(retryAfterHeader);
+  if (!Number.isNaN(retryAfterSeconds)) {
+    return retryAfterSeconds * 1000;
+  }
+
+  const retryAfterDate = new Date(retryAfterHeader);
+  const retryAfterTimestamp = retryAfterDate.getTime();
+  if (Number.isNaN(retryAfterTimestamp)) {
+    return null;
+  }
+
+  return Math.max(0, retryAfterTimestamp - Date.now());
+};
+
+const normalizeRetryOptions = (retryOptions = {}) => ({
+  ...DEFAULT_RETRY_OPTIONS,
+  ...retryOptions,
+  retryableStatuses:
+    retryOptions.retryableStatuses || DEFAULT_RETRY_OPTIONS.retryableStatuses,
+  retryableMethods:
+    retryOptions.retryableMethods || DEFAULT_RETRY_OPTIONS.retryableMethods,
+});
+
+const isMethodRetryable = (method, retryOptions) =>
+  retryOptions.safeToRetry || retryOptions.retryableMethods.includes(method);
+
+const calculateRetryDelay = ({
+  attempt,
+  retryOptions,
+  retryAfterDelayMs = null,
+}) => {
+  if (retryAfterDelayMs !== null) {
+    return Math.min(retryOptions.maxDelayMs, retryAfterDelayMs);
+  }
+
+  const exponentialDelay =
+    retryOptions.initialDelayMs *
+    Math.pow(retryOptions.backoffMultiplier, attempt);
+  const jitter = exponentialDelay * retryOptions.jitterRatio * Math.random();
+
+  return Math.min(
+    retryOptions.maxDelayMs,
+    Math.round(exponentialDelay + jitter)
+  );
+};
+
+const shouldRetryResponse = ({ response, attempt, method, retryOptions }) =>
+  attempt < retryOptions.maxRetries &&
+  isMethodRetryable(method, retryOptions) &&
+  retryOptions.retryableStatuses.includes(response.status);
+
+const shouldRetryError = ({ attempt, method, retryOptions }) =>
+  attempt < retryOptions.maxRetries && isMethodRetryable(method, retryOptions);
+
+export class ApiClientError extends Error {
+  constructor(message, { status, data, response, cause, url } = {}) {
+    super(message);
+    this.name = "ApiClientError";
+    this.status = status;
+    this.data = data;
+    this.response = response;
+    this.cause = cause;
+    this.url = url;
+  }
+}
+
+export const formatRetryDelay = (delayMs) => {
+  if (delayMs >= 1000) {
+    const seconds = delayMs / 1000;
+    return `${seconds % 1 === 0 ? seconds.toFixed(0) : seconds.toFixed(1)}s`;
+  }
+
+  return `${delayMs}ms`;
+};
+
+export const createRetryMessage = ({
+  attempt,
+  maxRetries,
+  delayMs,
+  resourceLabel = "Request",
+}) =>
+  `${resourceLabel} failed temporarily. Retrying ${attempt} of ${maxRetries} in ${formatRetryDelay(delayMs)}...`;
+
+export const fetchWithRetry = async (input, init = {}, retryOptions = {}) => {
+  const normalizedRetryOptions = normalizeRetryOptions(retryOptions);
+  const method = normalizeMethod(init);
+  const url = getRequestUrl(input);
+
+  for (
+    let attempt = 0;
+    attempt <= normalizedRetryOptions.maxRetries;
+    attempt += 1
+  ) {
+    try {
+      const response = await fetch(input, init);
+
+      if (
+        !response.ok &&
+        shouldRetryResponse({
+          response,
+          attempt,
+          method,
+          retryOptions: normalizedRetryOptions,
+        })
+      ) {
+        const delayMs = calculateRetryDelay({
+          attempt,
+          retryOptions: normalizedRetryOptions,
+          retryAfterDelayMs: getRetryAfterDelayMs(response),
+        });
+
+        normalizedRetryOptions.onRetry?.({
+          attempt: attempt + 1,
+          maxRetries: normalizedRetryOptions.maxRetries,
+          delayMs,
+          method,
+          response,
+          url,
+        });
+
+        await wait(delayMs);
+        continue;
+      }
+
+      return response;
+    } catch (error) {
+      if (
+        !shouldRetryError({
+          attempt,
+          method,
+          retryOptions: normalizedRetryOptions,
+        })
+      ) {
+        throw error;
+      }
+
+      const delayMs = calculateRetryDelay({
+        attempt,
+        retryOptions: normalizedRetryOptions,
+      });
+
+      normalizedRetryOptions.onRetry?.({
+        attempt: attempt + 1,
+        maxRetries: normalizedRetryOptions.maxRetries,
+        delayMs,
+        method,
+        error,
+        url,
+      });
+
+      await wait(delayMs);
+    }
+  }
+
+  throw new ApiClientError("Request failed after retrying.", { url });
+};
+
+export const parseResponseData = async (response) => {
+  const contentType = response.headers.get("content-type") || "";
+
+  if (contentType.includes("application/json")) {
+    try {
+      return await response.json();
+    } catch (error) {
+      return null;
+    }
+  }
+
+  try {
+    const text = await response.text();
+    return text || null;
+  } catch (error) {
+    return null;
+  }
+};
+
+const getResponseErrorMessage = (response, data) => {
+  if (data && typeof data === "object") {
+    if (typeof data.error === "string" && data.error.trim()) {
+      return data.error;
+    }
+
+    if (typeof data.message === "string" && data.message.trim()) {
+      return data.message;
+    }
+  }
+
+  if (response.statusText) {
+    return response.statusText;
+  }
+
+  return `Request failed with status ${response.status}`;
+};
+
+export const fetchJsonWithRetry = async (
+  input,
+  init = {},
+  retryOptions = {}
+) => {
+  const response = await fetchWithRetry(input, init, retryOptions);
+  const data = await parseResponseData(response);
+
+  if (!response.ok) {
+    throw new ApiClientError(getResponseErrorMessage(response, data), {
+      status: response.status,
+      data,
+      response,
+      url: getRequestUrl(input),
+    });
+  }
+
+  return { data, response };
+};


### PR DESCRIPTION
## Problem
Temporary network failures were immediately shown as user-facing errors, even in cases where retrying the request shortly afterward would likely succeed. This made predictor and scholarship flows less resilient than they should be.

## Solution
- Added a shared API client in `utils/apiClient.js`
- Implemented exponential backoff with configurable retry limits
- Added retry handling for:
  - predictor data loading in `pages/college_predictor.js`
  - rank estimation requests in `pages/college_predictor.js`
  - rank estimation requests in `pages/index.js`
  - scholarship data loading in `components/ScholarshipReferenceBrowser.js`
- Passed retry configuration through `pages/scholarships.js`
- Added lightweight retry-status feedback so users can see when the app is retrying

## Changes Made
- Created `utils/apiClient.js`
- Centralized retryable fetch behavior
- Added bounded retry rules and retry delay calculation
- Limited retries to safe or explicitly allowed request flows
- Preserved final error handling when retries are exhausted

## Impact
The app now handles temporary network issues more gracefully, improving reliability for predictor and scholarship experiences without requiring users to manually retry immediately.

## Testing
- Verified normal successful requests still work
- Verified retry logic is used by predictor and scholarship fetch flows
- Verified final errors are shown if retries are exhausted
- Verified production build passes with `npm run build`

## Files Changed
- `utils/apiClient.js` - new shared retrying API client
- `pages/college_predictor.js`
- `pages/index.js`
- `pages/scholarships.js`
- `components/ScholarshipReferenceBrowser.js`

## Notes
Although the original plan mentioned `pages/scholarships.js`, the actual scholarship data fetch happens inside `components/ScholarshipReferenceBrowser.js`, so that component was updated directly.  
`pages/index.js` was also included because it contains the home-page rank estimation request and needed the same retry behavior.

## Closes
Closes #215 