### PR TITLE
Fix misleading NEETUG filters by aligning the form with supported dataset fields

### DIFF
--- a/examConfig.js
+++ b/examConfig.js
@@ -319,18 +319,32 @@ export const jeeAdvancedConfig = {
   },
 };
 
-// Mapping from filter values to database values for seat type
-
-const seatTypeMap = {
-  "All India/Open Seat": "Open Seat",
-  "Deemed/Paid": "Deemed/Paid Seats",
-  "Non-Resident Indian": "Non-Resident Indian",
-  "Foreign National": "Foreign Country",
-  "Aligarh Muslim University": "Aligarh Muslim University (AMU)",
-  "Employees State Insurance": "Employees State Insurance Scheme(ESI)",
-  "Jamia": "Jamia Internal",
-  "Delhi University": "Delhi University",
-};
+const neetUgSeatTypeOptions = [
+  "Any",
+  "All India",
+  "Open Seat",
+  "Deemed/Paid Seats",
+  "Delhi University",
+  "IP University",
+  "Delhi NCR Children/Widows of Personnel of the Armed Forces (CW)",
+  "Aligarh Muslim University (AMU)",
+  "Jamia Internal",
+  "Jain Minority",
+  "Muslim",
+  "Muslim Minority",
+  "Muslim OBC",
+  "Muslim ST",
+  "Muslim Women",
+  "Employees State Insurance Scheme(ESI)",
+  "Employees State Insurance Scheme Nursing",
+  "Internal -Puducherry UT Domicile",
+  "Non-Resident Indian",
+  "Non-Resident Indian(AMU)",
+  "Foreign Country",
+  "B.Sc Nursing All India",
+  "B.Sc Nursing Delhi NCR",
+  "B.Sc Nursing Delhi NCR CW",
+];
 
 export const neetUGConfig = {
   name: "NEETUG",
@@ -375,60 +389,9 @@ export const neetUGConfig = {
       ],
     },
     {
-      name: "religion",
-      label: "Select Religion",
-      options: [
-        { value: "jain", label: "Jain" },
-        { value: "muslim", label: "Muslim" },
-        { value: "other", label: "Other" },
-      ],
-    },
-    {
-      name: "nationality",
-      label: "Select Nationality",
-      options: [
-        { value: "indian", label: "Indian" },
-        { value: "non resident", label: "Non Resident" },
-        { value: "other", label: "Other" },
-      ],
-    },
-    {
-      name: "region",
-      label: "Select Region",
-      options: [
-        { value: "delhi ncr", label: "Delhi NCR" },
-        { value: "puducherry", label: "Puducherry" },
-        { value: "other", label: "Other" },
-      ],
-    },
-    {
-      name: "defence_war",
-      label: "Defence War Quota",
-      options: [
-        { value: "Yes", label: "Yes" },
-        { value: "No", label: "No" },
-      ],
-    },
-    {
       name: "seat_type",
-      label: "Seat Type",
-      options: [
-        { value: "Any", label: "Any" },
-        { value: "All India/Open Seat", label: "All India/Open Seat" },
-        { value: "Deemed/Paid", label: "Deemed/Paid" },
-        { value: "Non-Resident Indian", label: "Non-Resident Indian" },
-        { value: "Foreign National", label: "Foreign National" },
-        {
-          value: "Aligarh Muslim University",
-          label: "Aligarh Muslim University",
-        },
-        {
-          value: "Employees State Insurance",
-          label: "Employees State Insurance",
-        },
-        { value: "Jamia", label: "Jamia" },
-        { value: "Delhi University", label: "Delhi University" },
-      ],
+      label: "Seat Type / Quota",
+      options: neetUgSeatTypeOptions,
     },
   ],
   legend: [
@@ -444,6 +407,7 @@ export const neetUGConfig = {
       String(str || "")
         .replace(/[^a-zA-Z0-9]/g, "")
         .toLowerCase();
+    const selectedSeatType = query.seat_type;
     return [
       (item) => {
         if (query.program) {
@@ -471,39 +435,16 @@ export const neetUGConfig = {
       },
       (item) => {
         if (query.category) {
-          return item["Category"] == query.category;
+          return normalize(item["Category"]) === normalize(query.category);
         }
         return true;
       },
       (item) => {
-        if (query.religion != "Other") {
-          return item["Seat Type"] == query.religion;
-        }
-        return true;
-      },
-      (item) => {
-        // If seat_type is 'All India' (Any), skip filtering
-
         if (
-          query.seat_type &&
-          String(query.seat_type).trim().toLowerCase() !== "any"
+          selectedSeatType &&
+          normalize(selectedSeatType) !== normalize("Any")
         ) {
-          const dbValue = seatTypeMap[query.seat_type] || query.seat_type;
-          if (dbValue == "Open Seat") {
-            return (
-              String(item["Seat Type"] || "")
-                .trim()
-                .toLowerCase() === String(dbValue).trim().toLowerCase() ||
-              String(item["Seat Type"] || "")
-                .trim()
-                .toLowerCase() === String("All India").trim().toLowerCase()
-            );
-          }
-          return (
-            String(item["Seat Type"] || "")
-              .trim()
-              .toLowerCase() === String(dbValue).trim().toLowerCase()
-          );
+          return normalize(item["Seat Type"]) === normalize(selectedSeatType);
         }
         return true;
       },

--- a/scripts/verify-local-routes.mjs
+++ b/scripts/verify-local-routes.mjs
@@ -48,8 +48,32 @@ const cases = [
   },
   {
     name: "NEETUG API",
-    path: "/api/exam-result?exam=NEETUG&program=MBBS&gender=Open&category=Open&religion=Other&nationality=Indian&region=Other&defence_war=No&seat_type=Any&rank=50000",
+    path: "/api/exam-result?exam=NEETUG&program=MBBS&gender=Open&category=Open&seat_type=Any&rank=50000",
     expectJsonArray: true,
+    validate: (rows) => {
+      const allowedSeatTypes = new Set(
+        rows
+          .map((row) => String(row["Seat Type"] || "").trim())
+          .filter(Boolean)
+      );
+      if (!allowedSeatTypes.has("All India")) {
+        throw new Error("Expected All India seat type in baseline NEETUG results");
+      }
+    },
+  },
+  {
+    name: "NEETUG Seat Type Filter",
+    path: "/api/exam-result?exam=NEETUG&program=MBBS&gender=Open&category=Open&seat_type=Non-Resident%20Indian&rank=50000",
+    expectJsonArray: true,
+    validate: (rows) => {
+      const invalidSeatTypeRow = rows.find(
+        (row) =>
+          String(row["Seat Type"] || "").trim() !== "Non-Resident Indian"
+      );
+      if (invalidSeatTypeRow) {
+        throw new Error("NEETUG seat_type filter returned rows from other quotas");
+      }
+    },
   },
   {
     name: "TGEAPCET API",


### PR DESCRIPTION
## What this fixes

This PR cleans up the NEETUG predictor filters.

Earlier, the form showed a few filters that were not actually supported by the dataset, so changing them either had no effect or could be misleading for students. That makes the predictor feel more precise than it really is.

## What changed

- removed unsupported NEETUG filters
- kept only filters that are backed by real dataset fields
- fixed `Seat Type / Quota` so it uses actual dataset values
- added a small regression check for NEETUG filtering

## Why this matters

Students should only see filters that genuinely change their results. This makes the NEETUG flow clearer, more trustworthy, and easier to use.
