### PR TITLE
feat: implement ACPC Merit Score calculator for GUJCET predictor

### DIFF
--- a/components/GujcetScoreCalculator.js
+++ b/components/GujcetScoreCalculator.js
@@ -1,0 +1,200 @@
+import React, { useState, useEffect } from "react";
+
+const GujcetScoreCalculator = ({
+  program,
+  initialBoardPercentage = "",
+  initialGujcetPercentile = "",
+  initialScore = "",
+  onScoreChange,
+  readOnlyRank = false,
+}) => {
+  const [inputMode, setInputMode] = useState(
+    initialBoardPercentage || initialGujcetPercentile 
+      ? "calculate" 
+      : (initialScore ? "known" : "calculate")
+  );
+  
+  const [boardPercentage, setBoardPercentage] = useState(initialBoardPercentage);
+  const [gujcetPercentile, setGujcetPercentile] = useState(initialGujcetPercentile);
+  const [knownScore, setKnownScore] = useState(initialScore && !initialBoardPercentage && !initialGujcetPercentile ? initialScore : "");
+  const [compositeScore, setCompositeScore] = useState("");
+
+  useEffect(() => {
+    setBoardPercentage(initialBoardPercentage);
+  }, [initialBoardPercentage]);
+
+  useEffect(() => {
+    setGujcetPercentile(initialGujcetPercentile);
+  }, [initialGujcetPercentile]);
+
+  useEffect(() => {
+    if (inputMode === "calculate") {
+      calculateAndPropagateScore(boardPercentage, gujcetPercentile, program);
+    } else {
+      propagateKnownScore(knownScore);
+    }
+  }, [boardPercentage, gujcetPercentile, program, inputMode, knownScore]);
+
+  const handleInputChange = (setter) => (e) => {
+    const value = e.target.value;
+    if (value === "" || (parseFloat(value) >= 0 && parseFloat(value) <= 100)) {
+      setter(value);
+    }
+  };
+
+  const propagateKnownScore = (score) => {
+    setCompositeScore(score);
+    if (onScoreChange) {
+      onScoreChange(score, "", "");
+    }
+  };
+
+  const calculateAndPropagateScore = (board, gujcet, currentProgram) => {
+    let finalScore = "";
+    
+    if (currentProgram === "Medical") {
+      // For Medical/Nursing: only board percentage is considered
+      if (board !== "") {
+        finalScore = parseFloat(board).toFixed(2);
+      }
+    } else {
+      // For Engineering and Pharmacy: 60% Board + 40% GUJCET
+      if (board !== "" && gujcet !== "") {
+        const boardWeight = parseFloat(board) * 0.6;
+        const gujcetWeight = parseFloat(gujcet) * 0.4;
+        finalScore = (boardWeight + gujcetWeight).toFixed(2);
+      }
+    }
+
+    setCompositeScore(finalScore);
+    if (onScoreChange) {
+      onScoreChange(finalScore, board, gujcet);
+    }
+  };
+
+  const getBoardLabel = () => {
+    if (program === "Engineering") return "Enter 12th Board PCM Percentage";
+    if (program === "Medical") return "Enter 12th Board PCB Percentage";
+    if (program === "Pharmacy") return "Enter 12th Board PCB/PCM Percentage";
+    return "Enter 12th Board Percentage";
+  };
+
+  const getFormulaText = () => {
+    if (program === "Medical") {
+      return "Medical/Nursing admissions do not use GUJCET. ACPC Merit Score = 12th Board PCB Percentage.";
+    }
+    return "ACPC Merit Score = (Board Percentage × 0.6) + (GUJCET Percentile × 0.4)";
+  };
+
+  return (
+    <div className="w-full sm:w-3/4">
+      {!readOnlyRank && (
+        <div className="my-4">
+          <label className="mb-2 block text-left text-md font-semibold text-gray-700">
+            How would you like to enter your ACPC Merit Score?
+          </label>
+          <div className="flex w-full justify-center">
+            <div className="inline-flex w-full overflow-hidden rounded-xl border border-[#d8c7c1]">
+              <button
+                type="button"
+                onClick={() => setInputMode("calculate")}
+                className={`flex-1 px-4 py-2 text-sm ${
+                  inputMode === "calculate"
+                    ? "bg-[#B52326] text-white"
+                    : "bg-white text-gray-700 hover:bg-gray-50"
+                }`}
+              >
+                Calculate from marks
+              </button>
+              <button
+                type="button"
+                onClick={() => setInputMode("known")}
+                className={`flex-1 px-4 py-2 text-sm ${
+                  inputMode === "known"
+                    ? "bg-[#B52326] text-white"
+                    : "bg-white text-gray-700 hover:bg-gray-50"
+                }`}
+              >
+                I know my score
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {inputMode === "calculate" ? (
+        <>
+          <div className="my-4 w-full sm:w-3/4">
+            <label className="mb-2 block text-left text-md font-semibold text-gray-700">
+          {getBoardLabel()}
+        </label>
+        <input
+          type="number"
+          step="0.01"
+          min="0"
+          max="100"
+          value={boardPercentage}
+          onChange={handleInputChange(setBoardPercentage)}
+          className="w-full rounded-xl border border-[#d8c7c1] bg-[#fffdfa] p-3 text-center outline-none transition focus:border-[#b52326] focus:ring-2 focus:ring-[#f4d5d6]"
+          placeholder="e.g., 85.50"
+        />
+      </div>
+
+      {program !== "Medical" && (
+        <div className="my-4 w-full sm:w-3/4">
+          <label className="mb-2 block text-left text-md font-semibold text-gray-700">
+            Enter GUJCET Percentile
+          </label>
+          <input
+            type="number"
+            step="0.01"
+            min="0"
+            max="100"
+            value={gujcetPercentile}
+            onChange={handleInputChange(setGujcetPercentile)}
+            className="w-full rounded-xl border border-[#d8c7c1] bg-[#fffdfa] p-3 text-center outline-none transition focus:border-[#b52326] focus:ring-2 focus:ring-[#f4d5d6]"
+            placeholder="e.g., 90.25"
+          />
+        </div>
+      )}
+
+      <div className="my-4 w-full sm:w-3/4">
+        <label className="mb-2 block text-left text-md font-semibold text-gray-700">
+          ACPC Merit Score Percentage (out of 100)
+        </label>
+        <input
+          type="text"
+          value={compositeScore}
+          readOnly
+          className="w-full rounded-xl border border-[#d8c7c1] bg-[#f8efec] p-3 text-center font-bold text-gray-800"
+          placeholder="Calculated Score"
+        />
+            {!readOnlyRank && (
+              <p className="text-xs text-gray-600 mt-1">
+                {getFormulaText()}
+              </p>
+            )}
+          </div>
+        </>
+      ) : (
+        <div className="my-4 w-full sm:w-3/4">
+          <label className="mb-2 block text-left text-md font-semibold text-gray-700">
+            Enter Known ACPC Merit Score Percentage
+          </label>
+          <input
+            type="number"
+            step="0.01"
+            min="0"
+            max="100"
+            value={knownScore}
+            onChange={handleInputChange(setKnownScore)}
+            className="w-full rounded-xl border border-[#d8c7c1] bg-[#fffdfa] p-3 text-center outline-none transition focus:border-[#b52326] focus:ring-2 focus:ring-[#f4d5d6]"
+            placeholder="e.g., 85.50"
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default GujcetScoreCalculator;

--- a/examConfig.js
+++ b/examConfig.js
@@ -1061,7 +1061,7 @@ export const gujcetConfig = {
   name: "GUJCET",
   code: "GUJCET",
   searchKeys: ["College Name", "District", "Course"],
-  primaryInput: decimalInput("Enter Percentage Score", "e.g., 78.45"),
+  primaryInput: decimalInput("Enter ACPC Merit Score Percentage", "e.g., 78.45"),
   fields: [
     {
       name: "category",

--- a/pages/college_predictor.js
+++ b/pages/college_predictor.js
@@ -7,6 +7,7 @@ import Fuse from "fuse.js";
 import examConfigs from "../examConfig";
 import dynamic from "next/dynamic";
 import TneaScoreCalculator from "../components/TneaScoreCalculator";
+import GujcetScoreCalculator from "../components/GujcetScoreCalculator";
 import { debounce } from "lodash";
 
 // Dynamically import Dropdown with SSR disabled
@@ -144,6 +145,19 @@ const CollegePredictor = () => {
         const m = parseFloat(initialQuery.mathsMarks);
         if (!isNaN(p) && !isNaN(c) && !isNaN(m)) {
           initialQuery.rank = ((p / 100) * 50 + (c / 100) * 50 + m).toFixed(2);
+        }
+      }
+    } else if (router.query.exam === "GUJCET" && !initialQuery.rank) {
+      if (initialQuery.boardPercentage && initialQuery.gujcetPercentile) {
+        const board = parseFloat(initialQuery.boardPercentage);
+        const gujcet = parseFloat(initialQuery.gujcetPercentile);
+        if (!isNaN(board) && !isNaN(gujcet)) {
+          initialQuery.rank = (board * 0.6 + gujcet * 0.4).toFixed(2);
+        }
+      } else if (initialQuery.boardPercentage && initialQuery.program === "Medical") {
+        const board = parseFloat(initialQuery.boardPercentage);
+        if (!isNaN(board)) {
+          initialQuery.rank = board.toFixed(2);
         }
       }
     }
@@ -296,6 +310,17 @@ const CollegePredictor = () => {
     };
     setQueryObject(newQueryObject);
     // Optimistically update queryObject, debouncedRouterPush will handle the actual route update and fetch
+    debouncedRouterPush(newQueryObject);
+  };
+
+  const handleGujcetScoreChange = (score, board, gujcet) => {
+    const newQueryObject = {
+      ...queryObject,
+      rank: score,
+      boardPercentage: board,
+      gujcetPercentile: gujcet,
+    };
+    setQueryObject(newQueryObject);
     debouncedRouterPush(newQueryObject);
   };
 
@@ -600,7 +625,7 @@ const CollegePredictor = () => {
       });
 
     const primaryInputCard =
-      queryObject.exam !== "JoSAA" && queryObject.exam !== "TNEA"
+      queryObject.exam !== "JoSAA" && queryObject.exam !== "TNEA" && queryObject.exam !== "GUJCET"
           ? renderSelectionCard(
             "rank",
             getPrimaryInputConfig(queryObject.exam).label,
@@ -926,6 +951,14 @@ const CollegePredictor = () => {
             initialChemistry={queryObject.chemistryMarks || ""}
             initialMaths={queryObject.mathsMarks || ""}
             onScoreChange={handleTneaScoreChange}
+            readOnlyRank={true}
+          />
+        ) : queryObject.exam === "GUJCET" ? (
+          <GujcetScoreCalculator
+            program={queryObject.program || ""}
+            initialBoardPercentage={queryObject.boardPercentage || ""}
+            initialGujcetPercentile={queryObject.gujcetPercentile || ""}
+            onScoreChange={handleGujcetScoreChange}
             readOnlyRank={true}
           />
         ) : null}

--- a/pages/index.js
+++ b/pages/index.js
@@ -6,6 +6,7 @@ import { useRouter } from "next/router";
 import Head from "next/head";
 import dynamic from "next/dynamic";
 import TneaScoreCalculator from "../components/TneaScoreCalculator";
+import GujcetScoreCalculator from "../components/GujcetScoreCalculator";
 
 // Dynamically import Dropdown with SSR disabled
 const Dropdown = dynamic(() => import("../components/dropdown"), {
@@ -359,6 +360,15 @@ const ExamForm = () => {
     }));
   };
 
+  const handleGujcetScoreChange = (score, board, gujcet) => {
+    setFormData((prevData) => ({
+      ...prevData,
+      rank: score,
+      boardPercentage: board,
+      gujcetPercentile: gujcet,
+    }));
+  };
+
   const handleSubmit = async () => {
     // For JoSAA exam
     if (selectedExam === "JoSAA") {
@@ -416,6 +426,24 @@ const ExamForm = () => {
                 "physicsMarks",
                 "chemistryMarks",
                 "mathsMarks",
+              ].includes(key)
+          )
+          .some(([_, value]) => !value)
+      );
+    }
+
+    // For GUJCET exam
+    if (selectedExam === "GUJCET") {
+      return (
+        !formData.rank ||
+        formData.rank === "" ||
+        Object.entries(formData)
+          .filter(
+            ([key]) =>
+              ![
+                "rank",
+                "boardPercentage",
+                "gujcetPercentile",
               ].includes(key)
           )
           .some(([_, value]) => !value)
@@ -577,6 +605,13 @@ const ExamForm = () => {
               {selectedExam && selectedExam === "TNEA" ? (
                 <div className="md:col-span-2">
                   <TneaScoreCalculator onScoreChange={handleTneaScoreChange} />
+                </div>
+              ) : selectedExam && selectedExam === "GUJCET" ? (
+                <div className="md:col-span-2">
+                  <GujcetScoreCalculator 
+                    program={formData.program} 
+                    onScoreChange={handleGujcetScoreChange} 
+                  />
                 </div>
               ) : (
                 selectedExam && (


### PR DESCRIPTION
This PR addresses an issue where the GUJCET predictor form vaguely asked for a "Percentage Score," causing confusion and inaccurate college filtering. Since ACPC Merit Scores are calculated differently depending on the chosen program (Engineering, Pharmacy, Medical), a dedicated calculator has been introduced to ensure accurate `closing_marks` comparisons. 
Users now have the option to easily calculate their exact ACPC Merit Score from their 12th Board marks and GUJCET percentile or manually enter a known score.
Fixes #238 
## Changes Made
* **`components/GujcetScoreCalculator.js`**: Created a new component to handle the UI and calculation logic:
  * Automatically applies the `60% Board + 40% GUJCET` formula for Engineering/Pharmacy programs.
  * Defaults to `100% Board` (ignoring GUJCET) for Medical programs.
  * Added a UI toggle allowing users to switch between "Calculate from marks" and "I know my score".
* **`pages/index.js`**: Replaced the default `primaryInput` field with the new `GujcetScoreCalculator` when the GUJCET exam is selected. Updated form validation logic to ensure calculator inputs are properly handled.
* **`pages/college_predictor.js`**: Added the new calculator to the results page to allow users to see and tweak their calculated/known score directly from the filters.
* **`examConfig.js`**: Updated the default configuration label to explicitly state "ACPC Merit Score Percentage" for better clarity.
## How to Test
1. Start the development server and navigate to the home page.
2. Select **GUJCET** from the "Select Exam/Counselling Process" dropdown.
3. Select **Engineering** and test the "Calculate from marks" option by entering `80` for board and `90` for GUJCET. Verify that the score calculates as `84`.
4. Change the program to **Medical** and verify that the GUJCET input hides, adjusting the calculation to purely use the Board percentage.
5. Click **"I know my score"** and verify that the UI simplifies to a single input.
6. Submit the form in both modes and verify that the application properly routes to `/college_predictor` and accurately filters the college tables based on the merit score.

<img width="1918" height="1021" alt="image" src="https://github.com/user-attachments/assets/056d48a2-b250-40e9-b79a-98fe3967adb5" />
<img width="1919" height="1083" alt="image" src="https://github.com/user-attachments/assets/df86c35b-a15d-4c1b-b9f5-706326f02b4c" />
