### PR TITLE
fix: block rank 0 submissions and add server-side validation

### DIFF
--- a/examConfig.js
+++ b/examConfig.js
@@ -58,7 +58,7 @@ const integerInput = (label, placeholder = label) => ({
   placeholder,
   inputType: "number",
   step: "1",
-  min: "0",
+  min: "1",
   allowDecimal: false,
 });
 

--- a/pages/api/exam-result.js
+++ b/pages/api/exam-result.js
@@ -78,6 +78,8 @@ export default async function handler(req, res) {
         error:
           primaryInputConfig.max !== undefined
             ? `Please enter a value between ${primaryInputConfig.min} and ${primaryInputConfig.max}.`
+            : primaryInputConfig.label.toLowerCase().includes("rank") && primaryInputConfig.min === "1"
+            ? "Please enter a rank greater than 0."
             : `Please enter a value greater than or equal to ${primaryInputConfig.min}.`,
       });
     }

--- a/pages/college_predictor.js
+++ b/pages/college_predictor.js
@@ -38,7 +38,7 @@ const defaultPrimaryInputConfig = {
   label: "Enter Rank",
   placeholder: "Enter your rank",
   step: "1",
-  min: "0",
+  min: "1",
   allowDecimal: false,
 };
 
@@ -53,6 +53,8 @@ const validatePrimaryInputValue = (exam, value) => {
   const rangeMessage =
     inputConfig.max !== undefined
       ? `Please enter a value between ${inputConfig.min} and ${inputConfig.max}.`
+      : inputConfig.label.toLowerCase().includes("rank") && inputConfig.min === "1"
+      ? "Please enter a rank greater than 0."
       : `Please enter a value greater than or equal to ${inputConfig.min}.`;
 
   if (Number.isNaN(numericValue)) {

--- a/pages/index.js
+++ b/pages/index.js
@@ -16,7 +16,7 @@ const defaultPrimaryInputConfig = {
   label: "Enter Rank",
   placeholder: "Enter your rank",
   step: "1",
-  min: "0",
+  min: "1",
   allowDecimal: false,
 };
 
@@ -31,6 +31,8 @@ const validatePrimaryInputValue = (exam, value) => {
   const rangeMessage =
     inputConfig.max !== undefined
       ? `Please enter a value between ${inputConfig.min} and ${inputConfig.max}.`
+      : inputConfig.label.toLowerCase().includes("rank") && inputConfig.min === "1"
+      ? "Please enter a rank greater than 0."
       : `Please enter a value greater than or equal to ${inputConfig.min}.`;
 
   if (Number.isNaN(numericValue)) {


### PR DESCRIPTION
## Description
This PR addresses a bug where the college predictor form allowed users to submit `0` as a rank for rank-based exams (such as JEE Main-JAC, MHT CET, KCET, etc.). Since rank 0 is mathematically processed as passing the closing rank filters (`0.9 * 0 = 0`), the API returned incorrect valid college predictions for rank 0.
Fixes #240 
## Changes Made
- **`examConfig.js`**: Updated `integerInput()` to enforce `min: "1"` for rank fields.
- **`pages/index.js` & `pages/college_predictor.js`**: 
  - Updated `defaultPrimaryInputConfig` to set a default minimum rank of `1`.
  - Upgraded `validatePrimaryInputValue()` to explicitly return `"Please enter a rank greater than 0."` when the user enters a rank less than 1, blocking submission on the frontend.
- **`pages/api/exam-result.js`**: Added server-side validation to return a `400 Bad Request` explicitly rejecting queries where the rank parameter is evaluated to `0` or less.
## How to Test
1. Select **JEE Main-JAC** as the exam on the home page.
2. Enter `0` in the All India Rank field.
3. Verify that a validation error appears stating *"Please enter a rank greater than 0."* and that the submit button is disabled.
4. Manually modify the URL parameter on the results page to `rank=0` and verify that the API rejects it, rather than displaying colleges like NSUT ECE.

<img width="1918" height="872" alt="image" src="https://github.com/user-attachments/assets/ed3c4b4d-e06f-482b-8468-2de3f8892b27" />
