### PR TITLE
fix: reset dropdown state when switching exams

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -522,6 +522,7 @@ const ExamForm = () => {
           ? field.label(formData)
           : field.label,
         <Dropdown
+          key={`${selectedExam}-${field.name}`}
           options={field.options.map((option) =>
             typeof option === "string"
               ? { value: option, label: option }


### PR DESCRIPTION
This PR fixes an issue where dropdown selections from a previously selected exam persisted after switching to a different exam. Because the dropdown components retained their internal state, fields such as category, gender, and home state sometimes continued showing stale values even after the form data was reset.

Fixes #251 

To resolve this, unique keys have been added to dropdown components to force proper remounting. This ensures that all exam-specific fields correctly reset to their default unselected state when users switch between exams.

<img width="1022" height="516" alt="Screenshot 2026-05-11 215453" src="https://github.com/user-attachments/assets/929f62e8-4a03-40be-a2e3-a3381e6e98c6" />

### Changes Made:
- Added unique keys to dropdown components to force remounting 
- **Unique Value Pattern** : key = exam_name-field_name
