### PR TITLE
fix: keep submit disabled for missing required fields

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -379,6 +379,11 @@ const ExamForm = () => {
     }));
   };
 
+  const hasMissingConfiguredFields = () => {
+    if (!config?.fields) return true;
+    return config.fields.some((field) => !formData[field.name]);
+  };
+
   const handleSubmit = async () => {
     // For JoSAA exam
     if (selectedExam === "JoSAA") {
@@ -428,17 +433,7 @@ const ExamForm = () => {
       return (
         !formData.rank ||
         formData.rank === "" ||
-        Object.entries(formData)
-          .filter(
-            ([key]) =>
-              ![
-                "rank",
-                "physicsMarks",
-                "chemistryMarks",
-                "mathsMarks",
-              ].includes(key)
-          )
-          .some(([_, value]) => !value)
+        hasMissingConfiguredFields()
       );
     }
 
@@ -476,9 +471,7 @@ const ExamForm = () => {
       !formData.rank ||
       formData.rank === "" ||
       formData.rank === 0 ||
-      Object.entries(formData)
-        .filter(([key]) => key !== "rank")
-        .some(([_, value]) => !value)
+      hasMissingConfiguredFields()
     );
   };
 


### PR DESCRIPTION
## Summary

This PR fixes a validation gap where entering only the rank could enable the submit button even when required dropdown fields were still empty.

The form now checks the selected exam’s required fields from `examConfig.js`, so submit stays disabled until all required fields are completed.

## Changes

- Detect missing required fields from the selected exam config.
- Keep submit disabled for non-JoSAA exams until rank and required dropdowns are filled.
- Keep submit disabled for TNEA until score and required dropdowns are filled.
- Leave JoSAA behavior unchanged.

## Manual Testing

1. Select `JEE Main-JAC`.
2. Enter a valid rank but leave dropdowns empty.
3. Confirm `Submit` stays disabled.
4. Fill all required dropdowns.
5. Confirm `Submit` becomes enabled.
6. Repeat once for `TNEA` by entering marks but leaving dropdowns empty.

### Before  Fix:
<img width="1918" height="879" alt="image" src="https://github.com/user-attachments/assets/e2647cc7-37b4-45db-bd66-cca0b6d1a86c" />

### After Fix:
<img width="598" height="412" alt="image" src="https://github.com/user-attachments/assets/e946b109-02d7-4ac3-a49b-00a348f80d5d" />


