### PR TITLE
Allow TNEA predictions across any course

### DIFF
--- a/examConfig.js
+++ b/examConfig.js
@@ -654,6 +654,7 @@ export const tneaConfig = {
       name: "courseType",
       label: "Select Course Type",
       options: [
+        "Any",
         "Computer Science",
         "Electronics and Communications (ECE)",
         "Mechanical",
@@ -725,7 +726,7 @@ export const tneaConfig = {
   },
   getFilters: (query) => [
     (item) => item.Category === query.category,
-    (item) => item.Course === query.courseType,
+    (item) => query.courseType === "Any" || item.Course === query.courseType,
     (item) => item.District === query.district || "Any" === query.district,
     (item) =>
       item["College Type"] === query.collegeType || "Any" === query.collegeType,


### PR DESCRIPTION
Adds an `Any` option to the TNEA course filter so students can explore eligible colleges across all courses.

## Changes
- Added `Any` to TNEA course options
- Updated TNEA filtering to skip course filtering when `Any` is selected

Fixes #257 

## Manual Test
- Selected TNEA with Course Type: `Any`
- Confirmed results include multiple courses
- Selected a specific course and confirmed results filter correctly

<img width="1919" height="1010" alt="image" src="https://github.com/user-attachments/assets/03087b1b-e3bd-47b0-a4f6-61a2fa7b551f" />

<img width="1916" height="1015" alt="image" src="https://github.com/user-attachments/assets/43354def-edf8-4afe-91a7-9ffd901b602f" />
