### PR TITLE
Improve disabled submit feedback

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -379,6 +379,41 @@ const ExamForm = () => {
     }));
   };
 
+  const getSubmitDisabledMessage = () => {
+    if (selectedExam === "JoSAA") {
+      const requiredDetailFields = [
+        "exam",
+        "category",
+        "gender",
+        "program",
+        "homeState",
+      ];
+      const hasMissingDetails = requiredDetailFields.some(
+        (field) => !formData[field]
+      );
+
+      if (hasMissingDetails) {
+        return "Please fill all the required fields before submitting!";
+      }
+
+      if (!formData.mainRank) {
+        return rankMode === "estimate"
+          ? "Estimate your JEE Main rank before submitting."
+          : "Enter your JEE Main rank.";
+      }
+
+      if (formData.qualifiedJeeAdv === "Yes" && !formData.advRank) {
+        return "Enter your JEE Advanced rank.";
+      }
+
+      if (rankError) {
+        return rankError;
+      }
+    }
+
+    return "Please fill all the required fields before submitting!";
+  };
+
   const handleSubmit = async () => {
     // For JoSAA exam
     if (selectedExam === "JoSAA") {
@@ -916,14 +951,7 @@ const ExamForm = () => {
                 </button>
                 {isSubmitDisabled() && (
                   <p className="mt-2 text-sm text-red-600">
-                    {selectedExam === "JoSAA" &&
-                    formData.qualifiedJeeAdv === "Yes" &&
-                    (!formData.advRank || formData.advRank === "")
-                      ? "Please enter your JEE Advanced rank."
-                      : selectedExam === "JoSAA" &&
-                        (!formData.mainRank || formData.mainRank === "")
-                      ? "Please enter your JEE Main rank."
-                      : "Please fill all the required fields before submitting!"}
+                    {getSubmitDisabledMessage()}
                   </p>
                 )}
               </div>


### PR DESCRIPTION
## Summary

Fixes the disabled submit message for the JoSAA form so the message matches the current form state and selected rank mode.

## Problem

Previously, the JoSAA form could show a rank-related error too early, such as asking the user to fill their rank immediately after selecting JoSAA.

That was confusing because:

- the user may still need to fill basic details like category, gender, program, and home state
- the message made it seem like rank was the only required input
- in rank prediction mode, there is no manual rank field visible, so asking the user to “enter rank” was inappropriate

## Changes

- Added a helper to decide the disabled submit message.
- For JoSAA, the form now first asks users to complete the required details.
- Only after the required JoSAA details are filled does it show rank-specific guidance.
- In prediction mode, the message asks the user to estimate their JEE Main rank.
- In known-rank mode, the message asks the user to enter their JEE Main rank.
- If JEE Advanced is selected, the form still asks for JEE Advanced rank when required.

## Before:
<img width="398" height="352" alt="Screenshot 2026-05-11 193822" src="https://github.com/user-attachments/assets/8bcf7dbb-6395-4fc9-83c6-e624166791c7" />

## After:
<img width="913" height="886" alt="image" src="https://github.com/user-attachments/assets/0603533d-9039-4c93-8e4f-e68a86062886" />

<img width="927" height="795" alt="image" src="https://github.com/user-attachments/assets/40f8544d-da7d-4dea-8894-9dfe60bc8e20" />

