### PR TITLE
feat(mht-cet): add consolidated course/branch filter

### DIFF
--- a/examConfig.js
+++ b/examConfig.js
@@ -465,6 +465,84 @@ export const neetUGConfig = {
   getSort: () => [["Closing Rank", "ASC"]],
 };
 
+const getMhtCetCategory = (programName) => {
+  if (!programName) return "Other Specializations";
+  const name = programName.replace(/\n/g, " ").trim().toLowerCase();
+
+  if (
+    name.includes("mechatronics") ||
+    name.includes("robotics") ||
+    name.includes("automation")
+  )
+    return "Mechatronics & Automation";
+  if (
+    name.includes("artificial") ||
+    name.includes("data science") ||
+    name.includes("data engineering") ||
+    name.includes("machine learning")
+  )
+    return "AI, ML & Data Science";
+  if (
+    name.includes("computer") ||
+    name.includes("information technology") ||
+    name.includes("software") ||
+    name.includes("cyber") ||
+    name.includes("iot") ||
+    name.includes("internet of things") ||
+    name.includes("business systems") ||
+    name.includes("design")
+  )
+    return "Computer Science & IT";
+  if (
+    name.includes("electronics") ||
+    name.includes("telecommunication") ||
+    name.includes("communication") ||
+    name.includes("vlsi") ||
+    name.includes("instrumentation")
+  )
+    return "Electronics & Telecommunication";
+  if (name.includes("electrical")) return "Electrical Engineering";
+  if (
+    name.includes("mechanical") ||
+    name.includes("automobile") ||
+    name.includes("aeronautical") ||
+    name.includes("manufacturing") ||
+    name.includes("production")
+  )
+    return "Mechanical Engineering";
+  if (
+    name.includes("civil") ||
+    name.includes("structural") ||
+    name.includes("infrastructure") ||
+    name.includes("environmental")
+  )
+    return "Civil Engineering";
+  if (
+    name.includes("chemical") ||
+    name.includes("petro") ||
+    name.includes("oil") ||
+    name.includes("paints") ||
+    name.includes("plastic") ||
+    name.includes("polymer") ||
+    name.includes("paper") ||
+    name.includes("dyestuff") ||
+    name.includes("surface coating") ||
+    name.includes("metallurgy") ||
+    name.includes("material")
+  )
+    return "Chemical & Materials";
+  if (
+    name.includes("food") ||
+    name.includes("bio") ||
+    name.includes("pharmaceutical")
+  )
+    return "Food, Bio & Pharma";
+  if (name.includes("textile") || name.includes("fibres"))
+    return "Textile Engineering";
+
+  return "Other Specializations";
+};
+
 export const mhtCetConfig = {
   name: "MHT CET",
   apiEndpoint: "mhtcet",
@@ -515,6 +593,24 @@ export const mhtCetConfig = {
         { value: "Yes", label: "Yes" },
       ],
     },
+    {
+      name: "courseType",
+      label: "Select Course/Branch",
+      options: [
+        "Any",
+        "Computer Science & IT",
+        "AI, ML & Data Science",
+        "Electronics & Telecommunication",
+        "Electrical Engineering",
+        "Mechanical Engineering",
+        "Mechatronics & Automation",
+        "Civil Engineering",
+        "Chemical & Materials",
+        "Food, Bio & Pharma",
+        "Textile Engineering",
+        "Other Specializations",
+      ],
+    },
   ],
   legend: [
     { key: "AI", value: "All India" },
@@ -535,6 +631,9 @@ export const mhtCetConfig = {
     (item) => item.State === query.homeState,
     (item) => item.PWD === query.isPWD,
     (item) => item.Defense === query.isDefenseWard,
+    (item) =>
+      query.courseType === "Any" ||
+      getMhtCetCategory(item["Academic Program Name"]) === query.courseType,
     (item) => {
       if (query.rank) {
         const closingRank = parseInt(item["Closing Rank"], 10);


### PR DESCRIPTION
# Description
Currently, the MHT-CET predictor displays eligible college/course results without a way to narrow them down by specific branches. Additionally, the raw dataset contains over 90 unique program names with many minor variants (e.g., multiple different CSE and AI subtypes), which would make a raw dropdown list overwhelming for users.

This PR introduces a course filter for MHT-CET that consolidates the fragmented list of programs into 11 broad, logical categories.

FIXES: #261 

# Key Changes
- **Consolidated Course Dropdown**: Replaced 90+ individual variants with 11 primary branch categories (Computer Science & IT, AI/ML, etc.).
- **Intelligent Branch Mapping**: Added a `getMhtCetCategory` helper function to map raw strings from the dataset to these categories, handling source data inconsistencies like newlines and extra spaces.
- **"Any" Option by Default**: Implemented an "Any" course option as the default to allow branch-agnostic exploration.
- **Specific Branch Logic**: Ensured specialized branches like Mechatronics and Automation are kept distinct from Mechanical Engineering.

# Branch Categories Included:
- **Computer Science & IT** (includes CSE, IT, Software, Cyber Security, IoT, etc.)
- **AI, ML & Data Science**
- **Electronics & Telecommunication** (includes ENTC, ECE, VLSI, etc.)
- **Electrical Engineering**
- **Mechanical Engineering** (Automobile, Aeronautical, etc.)
- **Mechatronics & Automation**
- **Civil Engineering**
- **Chemical & Materials** (Petro, Plastic, Polymer, etc.)
- **Food, Bio & Pharma**
- **Textile Engineering**
- **Other Specializations**

# How to Test
1. Navigate to the MHT-CET predictor.
2. Check the new **Select Course/Branch** dropdown.
3. Verify that selecting "Computer Science & IT" filters the results to show all relevant variants.
4. Verify that "Any" correctly shows all eligible results.
<img width="1919" height="1018" alt="image" src="https://github.com/user-attachments/assets/8d44ac5c-0b92-4afe-9a53-6360139918d2" />
<img width="1919" height="959" alt="image" src="https://github.com/user-attachments/assets/5c55f14b-de4d-4474-91b3-2cf4eabbfedf" />
