### PR TITLE
fix: PWD and Defense Ward filters return zero results for Female-Only students

### DIFF
--- a/examConfig.js
+++ b/examConfig.js
@@ -235,7 +235,7 @@ export const jacExamConfig = {
   getFilters: (query) => [
     (item) => item.State === query.homeState,
     (item) => item.Category === query.category,
-    (item) => item.Defense === query.isDefenseWard,
+    (item) => query.isDefenseWard === "No" ? item.Defense === "No" : true,
     // Fixed code
     (item) => query.isPWD === "No" ? item.PWD === "No" : true,
     (item) => item.Gender === query.gender,
@@ -594,7 +594,7 @@ export const mhtCetConfig = {
     (item) => item.State === query.homeState,
     // Fixed code
     (item) => query.isPWD === "No" ? item.PWD === "No" : true,
-    (item) => item.Defense === query.isDefenseWard,
+    (item) => query.isDefenseWard === "No" ? item.Defense === "No" : true,
     (item) => {
       if (query.rank) {
         const closingRank = parseInt(item["Closing Rank"], 10);

--- a/examConfig.js
+++ b/examConfig.js
@@ -236,7 +236,8 @@ export const jacExamConfig = {
     (item) => item.State === query.homeState,
     (item) => item.Category === query.category,
     (item) => item.Defense === query.isDefenseWard,
-    (item) => item.PWD === query.isPWD,
+    // Fixed code
+    (item) => query.isPWD === "No" ? item.PWD === "No" : true,
     (item) => item.Gender === query.gender,
     (item) =>
       parseInt(item["Closing Rank"], 10) > 0.9 * parseInt(query.rank, 10),
@@ -591,7 +592,8 @@ export const mhtCetConfig = {
     (item) => item.Category === query.category,
     (item) => item.Gender === query.gender,
     (item) => item.State === query.homeState,
-    (item) => item.PWD === query.isPWD,
+    // Fixed code
+    (item) => query.isPWD === "No" ? item.PWD === "No" : true,
     (item) => item.Defense === query.isDefenseWard,
     (item) => {
       if (query.rank) {


### PR DESCRIPTION
## Problem
When a student selects Female-Only gender with either 
PWD: Yes or Defense Ward: Yes, the predictor returns 
zero results even for valid ranks.

Note: This issue is specific to Female-Only gender. 
Gender-Neutral with PWD: Yes or Defense Ward: Yes 
returns results correctly in the original code.

This affects JEE Main-JAC and MHT CET exams.

## Steps to Reproduce
**PWD case:**
1. Exam: JEE Main-JAC
2. Rank: 1, Category: General
3. Gender: Female-Only
4. PWD: Yes
→ Result: "No predictions available"

Same inputs with PWD: No → 35 results shown

**Defense Ward case:**
1. Exam: JEE Main-JAC
2. Rank: 20000, Category: OBC
3. Gender: Female-Only
4. Defense Ward: Yes
→ Result: "No predictions available"

Same inputs with Defense Ward: No → 18 results shown

## Root Cause
Both filters use strict equality checks:

PWD filter (broken):
(item) => item.PWD === query.isPWD

Defense Ward filter (broken):
(item) => item.Defense === query.isDefenseWard

When PWD: Yes or Defense Ward: Yes is selected 
along with Female-Only gender, the filter looks 
for rows where both conditions are simultaneously 
true in the data. Since no Female-Only rows exist 
with PWD or Defense Ward specific cutoffs, zero 
rows match and the result is always empty.

## Why This is Wrong
PWD and Defense Ward are additional quotas — not 
restrictions. A Female-Only PWD or Defense Ward 
student is eligible for:
1. All Female-Only general seats
2. Any PWD/Defense Ward quota seats on top

So selecting PWD: Yes or Defense Ward: Yes should 
never return fewer results than selecting No for 
the same gender.

## Fix
Changed both filters to use inclusive logic:

PWD fix:
(item) => query.isPWD === "No" ? item.PWD === "No" : true

Defense Ward fix:
(item) => query.isDefenseWard === "No" ? item.Defense === "No" : true

- If No → only show general rows (unchanged behaviour)
- If Yes → show all rows since these students are 
  eligible for general seats plus any quota seats
- Gender filtering is handled separately by the 
  gender filter so Female-Only results remain 
  correctly filtered by gender

## Exams Fixed
- JEE Main-JAC (jacExamConfig)
- MHT CET (mhtCetConfig)

## Testing
**PWD filter:**
Exam: JEE Main-JAC, Rank: 1
Category: General, Gender: Female-Only
PWD: Yes → Before: 0 results, After: results shown 
PWD: No → 35 results (unchanged) 

**Defense Ward filter:**
Exam: JEE Main-JAC, Rank: 20000
Category: OBC, Gender: Female-Only
Defense Ward: Yes → Before: 0 results, After: 18 results 
Defense Ward: No → 18 results (unchanged) 

## Screenshots
<img width="1919" height="1017" alt="Screenshot 2026-05-16 184348" src="https://github.com/user-attachments/assets/46ad3b89-86d8-41bb-a7fb-36f14673c824" />
<img width="1919" height="1015" alt="Screenshot 2026-05-16 184536" src="https://github.com/user-attachments/assets/b038837e-62d4-40e4-9265-e8b82923e106" />
<img width="1919" height="1015" alt="Screenshot 2026-05-16 184621" src="https://github.com/user-attachments/assets/4746cd13-c52d-49ec-a357-188435d4ef74" />
<img width="1919" height="1019" alt="Screenshot 2026-05-16 184657" src="https://github.com/user-attachments/assets/4a020e08-c13e-4983-9684-9f30538af991" />
