### PR TITLE
feat: add CSV download button to scholarship reference list

### DIFF
--- a/components/ScholarshipReferenceBrowser.js
+++ b/components/ScholarshipReferenceBrowser.js
@@ -83,6 +83,43 @@ const ScholarshipReferenceBrowser = () => {
     }));
   };
 
+  const CSV_COLUMNS = [
+    { key: "Scholarship Name", label: "Scholarship Name" },
+    { key: "Status", label: "Status" },
+    { key: "Last Date", label: "Last Date" },
+    { key: "Stream", label: "Stream" },
+    { key: "State", label: "State" },
+    { key: "Eligibility", label: "Eligibility" },
+    { key: "Benefits", label: "Benefits" },
+    { key: "Scholarship Amount", label: "Scholarship Amount" },
+    { key: "Doc Required", label: "Documents Required" },
+    { key: "Special Criteria", label: "Special Criteria" },
+    { key: "Application Link", label: "Application Link" },
+  ];
+
+  const downloadCsv = () => {
+    if (!filteredScholarships.length) return;
+
+    const escape = (val) => {
+      const str = val === null || val === undefined ? "" : String(val);
+      return `"${str.replace(/"/g, '""')}"`;
+    };
+
+    const headerRow = CSV_COLUMNS.map((c) => escape(c.label)).join(",");
+    const dataRows = filteredScholarships.map((item) =>
+      CSV_COLUMNS.map((c) => escape(item[c.key])).join(",")
+    );
+
+    const csvContent = [headerRow, ...dataRows].join("\n");
+    const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.href = url;
+    link.download = `scholarships_${filteredScholarships.length}.csv`;
+    link.click();
+    URL.revokeObjectURL(url);
+  };
+
   return (
     <div className="min-h-screen bg-[#fdf8f6] px-4 py-8">
       <div className="mx-auto w-full max-w-6xl">
@@ -95,21 +132,29 @@ const ScholarshipReferenceBrowser = () => {
             as closed or deadline-passed.
           </p>
           {!isLoading && scholarships.length > 0 && (
-            <div className="mt-4 flex flex-wrap gap-2 text-sm text-[#5b3a34]">
-              <span className="rounded-full border border-[#e3d1cb] bg-[#fff7f4] px-3 py-1">
-                {scholarships.length.toLocaleString("en-IN")} scholarships in
-                the reference list
-              </span>
-              <span className="rounded-full border border-[#f0c7c8] bg-[#fff1f1] px-3 py-1 text-[#8f2e31]">
-                {closedCount.toLocaleString("en-IN")} currently closed or past
-                deadline
-              </span>
-              {showOnlyOpen && (
-                <span className="rounded-full border border-[#c3e6cb] bg-[#f0fff4] px-3 py-1 text-sm text-green-800">
-                  {filteredScholarships.length.toLocaleString("en-IN")} open now
+            <div className="mt-4 flex flex-wrap items-center justify-between gap-3">
+              <div className="flex flex-wrap gap-2 text-sm text-[#5b3a34]">
+                <span className="rounded-full border border-[#e3d1cb] bg-[#fff7f4] px-3 py-1">
+                  {scholarships.length.toLocaleString("en-IN")} scholarships in
+                  the reference list
                 </span>
-              )}
-
+                <span className="rounded-full border border-[#f0c7c8] bg-[#fff1f1] px-3 py-1 text-[#8f2e31]">
+                  {closedCount.toLocaleString("en-IN")} currently closed or past
+                  deadline
+                </span>
+                {showOnlyOpen && (
+                  <span className="rounded-full border border-[#c3e6cb] bg-[#f0fff4] px-3 py-1 text-sm text-green-800">
+                    {filteredScholarships.length.toLocaleString("en-IN")} open now
+                  </span>
+                )}
+              </div>
+              <button
+                onClick={downloadCsv}
+                disabled={filteredScholarships.length === 0}
+                className="rounded-lg bg-[#B52326] px-4 py-2 text-sm font-semibold text-white hover:bg-[#9E1F22] disabled:cursor-not-allowed disabled:bg-gray-300 disabled:text-gray-500"
+              >
+                Download CSV
+              </button>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
Adds a **Download CSV** button to the Scholarship Reference List page, bringing it to feature parity with the college predictions table.

The exported file reflects the currently filtered view — if the user has searched for `"engineering"` or toggled `"Show open only"`, the CSV contains only those results.

Fixes #269 
---

## Changes

### File Modified
- `components/ScholarshipReferenceBrowser.js`

### Added
- `CSV_COLUMNS` constant defining the 11 fields to export
- `downloadCsv()` function that:
  - Iterates over `filteredScholarships` (not the full list)
  - Wraps every cell value in double quotes and escapes internal quotes (`""`) to safely handle multi-line eligibility text
  - Triggers a browser download using `URL.createObjectURL`
  - Names the exported file as `scholarships_<count>.csv`

### UI Updates
- Restructured the stats badges row using `justify-between` so the button appears on the right
- Disabled the button when `filteredScholarships.length === 0`

---

## Notes
- No other files were modified.

<img width="1919" height="950" alt="image" src="https://github.com/user-attachments/assets/4c6952de-0ad7-4408-9d70-bc9ff28e6565" />
<img width="1662" height="844" alt="image" src="https://github.com/user-attachments/assets/9afa5376-500c-45b1-af92-c984cccfc935" />
