### PR TITLE
fix: correct JAC rank filter from > to >= for boundary rank consistency

### DIFF
--- a/examConfig.js
+++ b/examConfig.js
@@ -240,7 +240,7 @@ export const jacExamConfig = {
     (item) => item.PWD === query.isPWD,
     (item) => item.Gender === query.gender,
     (item) =>
-      parseInt(item["Closing Rank"], 10) > 0.9 * parseInt(query.rank, 10),
+      parseInt(item["Closing Rank"], 10) >= 0.9 * parseInt(query.rank, 10),
   ],
   getSort: () => [["Closing Rank", "ASC"]],
 };


### PR DESCRIPTION
## Summary

Fixes the JAC rank filter boundary condition where colleges at the exact `0.9 × rank` cutoff were being excluded from results.

Fixes #271 
## Root Cause

The JAC rank filter used a strict `>` comparison, while other exam predictors use `>=`.

Because all predictors follow the same `0.9` threshold logic, JAC should behave consistently with the others.

## Change

```diff
- parseInt(item["Closing Rank"], 10) > 0.9 * parseInt(query.rank, 10)
+ parseInt(item["Closing Rank"], 10) >= 0.9 * parseInt(query.rank, 10)
```

## Why this matters

A college with a closing rank exactly equal to `0.9 × userRank` should be included in predictions, just like it is for the other exam predictors.

This makes the filtering behavior consistent across all exams.