### PR TITLE
fix: add array validation after JSON.parse and remove error detail leaks

### DIFF
--- a/pages/api/exam-result.js
+++ b/pages/api/exam-result.js
@@ -109,6 +109,10 @@ export default async function handler(req, res) {
     const data = await fs.readFile(dataPath, "utf8");
     const fullData = JSON.parse(data);
 
+    if (!Array.isArray(fullData)) {
+      return res.status(500).json({ error: "Data format invalid" });
+    }
+
     // Get filters based on the exam config and query parameters
     const filters = config.getFilters(req.query);
 
@@ -264,7 +268,6 @@ export default async function handler(req, res) {
     console.error("Error reading file:", error);
     res.status(500).json({
       error: "Unable to retrieve data",
-      details: error.message,
     });
   }
 }

--- a/pages/api/scholarship-data.js
+++ b/pages/api/scholarship-data.js
@@ -12,12 +12,16 @@ export default async function handler(req, res) {
     );
     const data = await fs.readFile(dataPath, "utf8");
     const scholarships = JSON.parse(data);
+
+    if (!Array.isArray(scholarships)) {
+      return res.status(500).json({ error: "Data format invalid" });
+    }
+
     return res.status(200).json(scholarships);
   } catch (error) {
     console.error("Error loading scholarship data:", error);
     return res.status(500).json({
       error: "Unable to retrieve scholarship data",
-      details: error.message,
     });
   }
 }


### PR DESCRIPTION
## What this PR does

- Adds `Array.isArray()` validation after `JSON.parse()` in `exam-result.js` and `scholarship-data.js` to prevent `TypeError` crash when data file is malformed

- Removes `details: error.message` from catch blocks to stop leaking internal errors to clients

solves #273 

## Files changed

>  `pages/api/exam-result.js`
>  `pages/api/scholarship-data.js`
