### PR TITLE
fix: surface hidden MHT-CET TFWS seats by matching on Category_Key

### DIFF
--- a/examConfig.js
+++ b/examConfig.js
@@ -484,6 +484,7 @@ export const mhtCetConfig = {
         { value: "VJ", label: "VJ" },
         { value: "NT", label: "NT" },
         { value: "Orphan", label: "Orphan" },
+        { value: "TFWS", label: "TFWS" },
       ],
     },
     {
@@ -530,7 +531,12 @@ export const mhtCetConfig = {
     );
   },
   getFilters: (query) => [
-    (item) => item.Category === query.category,
+    (item) => {
+      if (query.category === "TFWS") {
+        return item.Category_Key === "TFWS";
+      }
+      return item.Category === query.category;
+    },
     (item) => item.Gender === query.gender,
     (item) => item.State === query.homeState,
     (item) => item.PWD === query.isPWD,


### PR DESCRIPTION
## Description

### What

Adds `TFWS` as a selectable category for MHT-CET and fixes the filter to correctly surface TFWS rows that currently have:

```json
"Category": null
```

in the dataset.

---

### Why

The MHT-CET dataset contains **362 TFWS rows** where `Category` is `null`.

The existing filter:

```js
item.Category === query.category
```

silently excludes all of these rows.

These rows are still identifiable because they contain:

```json
"Category_Key": "TFWS"
```

but the filter logic never checks that field.

---
### Fixes #276 
---
### Changes

#### File: `examConfig.js`

##### Added TFWS to the category dropdown

```diff
{ value: "Orphan", label: "Orphan" },
+ { value: "TFWS", label: "TFWS" },
],
```

##### Updated the category filter to route TFWS through `Category_Key`

```diff
getFilters: (query) => [
-   (item) => item.Category === query.category,
+   (item) => {
+     if (query.category === "TFWS") {
+       return item.Category_Key === "TFWS";
+     }
+     return item.Category === query.category;
+   },
```



### Notes

- Only `examConfig.js` is modified.
- No dataset or data file changes are required.
- The fix is intentionally scoped to TFWS because it is the only category where `Category` is `null`.
- Existing category filtering behavior remains unchanged for all other categories.
- Non-breaking change — existing category selections continue to work as before.







<img width="1919" height="1033" alt="image" src="https://github.com/user-attachments/assets/9a4902e6-da7a-42a7-89f1-6eae7e6eb453" />
