### PR TITLE
fix: JAC rank boundary exclusion and JSON array validation

### DIFF
--- a/examConfig.js
+++ b/examConfig.js
@@ -240,7 +240,7 @@ export const jacExamConfig = {
     (item) => item.PWD === query.isPWD,
     (item) => item.Gender === query.gender,
     (item) =>
-      parseInt(item["Closing Rank"], 10) > 0.9 * parseInt(query.rank, 10),
+      parseInt(item["Closing Rank"], 10) >= 0.9 * parseInt(query.rank, 10),
   ],
   getSort: () => [["Closing Rank", "ASC"]],
 };

--- a/pages/api/exam-result.js
+++ b/pages/api/exam-result.js
@@ -142,6 +142,11 @@ export default async function handler(req, res) {
     const data = await fs.readFile(dataPath, "utf8");
     const fullData = JSON.parse(data);
 
+    if (!Array.isArray(fullData)) {
+      console.error(`Data format error: expected array at ${dataPath}`);
+      return res.status(500).json({ error: "Data format error. Please try again later." });
+    }
+
     // Get filters based on the exam config and query parameters
     const filters = config.getFilters(req.query);
 

--- a/pages/api/scholarship-data.js
+++ b/pages/api/scholarship-data.js
@@ -12,6 +12,12 @@ export default async function handler(req, res) {
     );
     const data = await fs.readFile(dataPath, "utf8");
     const scholarships = JSON.parse(data);
+
+    if (!Array.isArray(scholarships)) {
+      console.error("Data format error: expected array in scholarship_data.json");
+      return res.status(500).json({ error: "Data format error. Please try again later." });
+    }
+
     return res.status(200).json(scholarships);
   } catch (error) {
     console.error("Error loading scholarship data:", error);


### PR DESCRIPTION
Fixes #271 - JAC `getFilters` used strict `>` instead of `>=`. Students 
whose rank exactly matched the boundary were excluded. 

Fixes #273 - Added `Array.isArray()` guard after `JSON.parse()` in both 
affected files. Without this, a malformed data file causes a silent 
`TypeError` crash with no meaningful error returned to the client.

**Changes (3 files):**
- `examConfig.js`: `>` → `>=` in JAC rank filter (#271)
- `pages/api/exam-result.js`: `Array.isArray()` check (#273)
- `pages/api/scholarship-data.js`: `Array.isArray()` check (#273)
