### PR TITLE
fix: charset declaration, scholarship expansion stability, and JAC rank boundary

### DIFF
--- a/components/ScholarshipReferenceBrowser.js
+++ b/components/ScholarshipReferenceBrowser.js
@@ -74,10 +74,10 @@ const ScholarshipReferenceBrowser = () => {
     [scholarships]
   );
 
-  const toggleRowExpansion = (index) => {
+  const toggleRowExpansion = (scholarshipName) => {
     setExpandedRows((prev) => ({
       ...prev,
-      [index]: !prev[index],
+      [scholarshipName]: !prev[scholarshipName],
     }));
   };
 

--- a/components/ScholarshipTable.js
+++ b/components/ScholarshipTable.js
@@ -174,8 +174,10 @@ const ScholarshipTable = ({
               </td>
             </tr>
           )}
-          {filteredData?.map((item, index) => (
-            <React.Fragment key={index}>
+          {filteredData?.map((item, index) => {
+            const scholarshipKey = item["Scholarship Name"] || String(index);
+            return (
+            <React.Fragment key={scholarshipKey}>
               <tr
                 className={`border-b border-[#eaded8] ${
                   index % 2 === 0 ? "bg-[#fffdfa]" : "bg-white"
@@ -214,17 +216,18 @@ const ScholarshipTable = ({
                 <TableCell>
                   <button
                     className="whitespace-nowrap rounded-lg bg-[#B52326] px-4 py-2 text-white hover:bg-[#9E1F22]"
-                    onClick={() => toggleRowExpansion(index)}
+                    onClick={() => toggleRowExpansion(scholarshipKey)}
                   >
-                    {expandedRows[index] ? "Show Less" : "Show More"}
+                    {expandedRows[scholarshipKey] ? "Show Less" : "Show More"}
                   </button>
                 </TableCell>
               </tr>
-              {expandedRows[index] && (
+              {expandedRows[scholarshipKey] && (
                 <ExpandedRow item={item} expandedFields={expandedFields} />
               )}
             </React.Fragment>
-          ))}
+            );
+          })}
         </tbody>
       </table>
     </div>

--- a/examConfig.js
+++ b/examConfig.js
@@ -239,7 +239,7 @@ export const jacExamConfig = {
     (item) => item.PWD === query.isPWD,
     (item) => item.Gender === query.gender,
     (item) =>
-      parseInt(item["Closing Rank"], 10) > 0.9 * parseInt(query.rank, 10),
+      parseInt(item["Closing Rank"], 10) >= 0.9 * parseInt(query.rank, 10),
   ],
   getSort: () => [["Closing Rank", "ASC"]],
 };

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -2,8 +2,9 @@ import { Head, Html, Main, NextScript } from "next/document";
 
 export default function Document() {
   return (
-    <Html>
+    <Html lang="en">
       <Head>
+        <meta charSet="UTF-8" />
         <link rel="icon" href="/favicon.ico" />
         <link rel="shortcut icon" href="/favicon.ico" />
       </Head>


### PR DESCRIPTION
## What this PR does

This PR fixes three separate correctness issues that were affecting students using the platform. All three are small, self-contained changes with a clear before/after behaviour.

### 1. Missing charset declaration causing garbled characters (closes #242)

The app had no `<meta charSet="UTF-8" />` in `pages/_document.js`, and the `<Html>` tag was missing `lang="en"`. On Windows and some mobile browsers, this causes the browser to fall back to Latin-1 encoding, which breaks any character above U+007F. In practice, students would see things like rupee signs, multiplication symbols, and bullet points rendered as nonsense. The fix is a two-line addition to `_document.js` that every Next.js Pages Router app should have.

### 2. Scholarship row expansion jumps to the wrong row after searching (closes #244)

The scholarship table was tracking which rows were expanded using the array index as the key. When a student searched or filtered the list, the positions of scholarships shifted, but the expansion state did not follow the scholarship identity. This meant the wrong scholarship would pop open after a search, and previously expanded scholarships would silently collapse or stay open depending on where they landed in the filtered list.

The fix is to use the scholarship name as the lookup key instead of the index. Since scholarship names are unique in the dataset, this ties the expanded state to the actual scholarship rather than its position in the current view. A fallback to `String(index)` is kept for any rows that happen to have a missing name field, so nothing breaks in edge cases.

### 3. JAC rank filter excluding students at the exact boundary (closes #271)

The JAC exam filter in `examConfig.js` used a strict `>` comparison for the closing rank check. Every other exam on the platform (JoSAA, NEETUG, KCET, TGEAPCET) uses `>=`. A student whose rank sits exactly at 90% of the closing rank was being silently excluded from results only on the JAC predictor. Changed to `>=` to match the behaviour everywhere else.

## Files changed

- `pages/_document.js` — added `lang="en"` and `charSet="UTF-8"`
- `components/ScholarshipReferenceBrowser.js` — `toggleRowExpansion` now takes scholarship name
- `components/ScholarshipTable.js` — expansion key is now scholarship name, not array index
- `examConfig.js` — JAC rank boundary changed from `>` to `>=`