### PR TITLE
fix: validate parsed JSON is an array before calling filter

### DIFF
--- a/pages/api/exam-result.js
+++ b/pages/api/exam-result.js
@@ -141,6 +141,9 @@ export default async function handler(req, res) {
     const dataPath = config.getDataPath(req.query.category);
     const data = await fs.readFile(dataPath, "utf8");
     const fullData = JSON.parse(data);
+    if (!Array.isArray(fullData)) {
+      return res.status(500).json({ error: "Data format invalid. Please try again later." });
+    }
 
     // Get filters based on the exam config and query parameters
     const filters = config.getFilters(req.query);

--- a/pages/api/scholarship-data.js
+++ b/pages/api/scholarship-data.js
@@ -12,6 +12,9 @@ export default async function handler(req, res) {
     );
     const data = await fs.readFile(dataPath, "utf8");
     const scholarships = JSON.parse(data);
+    if (!Array.isArray(scholarships)) {
+      return res.status(500).json({ error: "Scholarship data format invalid. Please try again later." });
+    }
     return res.status(200).json(scholarships);
   } catch (error) {
     console.error("Error loading scholarship data:", error);


### PR DESCRIPTION
## What this PR fixes

Closes #273

Both the exam result API and the scholarship data API read a JSON file from disk and immediately call array methods like `.filter()` on the parsed result. There was no check that the parsed value is actually an array.

If a data file ever gets corrupted, accidentally written as a JSON object instead of an array, or receives a partial write, `JSON.parse()` still succeeds but the returned value is not an array. The very next line that tries `.filter()` then throws a `TypeError: filteredData.filter is not a function` and the request fails with a 500 error and no helpful message for the student.

## What changed

Added a single `Array.isArray()` guard right after `JSON.parse()` in both handlers.

In `pages/api/exam-result.js`:

```js
const fullData = JSON.parse(data);
if (!Array.isArray(fullData)) {
  return res.status(500).json({ error: "Data format invalid. Please try again later." });
}
```

In `pages/api/scholarship-data.js`:

```js
const scholarships = JSON.parse(data);
if (!Array.isArray(scholarships)) {
  return res.status(500).json({ error: "Scholarship data format invalid. Please try again later." });
}
```

If the file is malformed, the API now returns a clean 500 with a plain human-readable message instead of letting the runtime error propagate. If the file is fine (which it always is in the normal case), the guard passes instantly and nothing else changes.

## Why this matters

The existing catch block only catches read errors and JSON parse errors. A valid JSON file that contains an object instead of an array would pass the parse step and fail silently later. This guard closes that gap. It is a small, targeted addition with no side effects on the normal flow.