### PR TITLE
fix: reset dropdown selections properly when switching between exams

### DIFF
--- a/components/dropdown.js
+++ b/components/dropdown.js
@@ -64,10 +64,12 @@ const Dropdown = ({
       styles={customStyles}
       instanceId={useId()}
       className={className}
-      value={options.find(
-        (option) =>
-          option.label === selectedValue || option.value === selectedValue
-      )}
+      value={
+        options.find(
+          (option) =>
+            option.label === selectedValue || option.value === selectedValue
+        ) ?? null
+      }
     />
   );
 };

--- a/pages/index.js
+++ b/pages/index.js
@@ -517,7 +517,7 @@ const ExamForm = () => {
 
     return fieldsToRender.map((field) =>
       renderFormCard(
-        field.name,
+        `${selectedExam}-${field.name}`,
         typeof field.label === "function"
           ? field.label(formData)
           : field.label,


### PR DESCRIPTION
## What this fixes

Closes #251

When a student selected an exam, filled in some fields, and then switched to a different exam, the dropdown fields did not visually reset. For example, selecting Engineering under JoSAA and then switching to NEETUG would leave Engineering still displayed in the program dropdown, even though the underlying formData had been cleared. A student could easily submit with stale values from a previous exam without realising it.

## Root cause

There were two issues layered on top of each other.

The first is in how react-select interprets the value prop. When no option matches the (now-empty) formData field after an exam change, options.find() returns undefined. React-select treats undefined as no instruction, so it keeps whatever it was showing before. Passing null explicitly tells it to clear the selection. The fix adds a null coalescing fallback so the Select component always receives null when there is no match.

The second is a React reconciliation issue. The key for each form field card was just field.name. When both the old exam and the new exam have a field with the same name (like category, gender, or program), React sees the same key in both renders and reuses the existing component instance rather than creating a new one. Even with the null fix in place, carrying the same component instance across exam switches is fragile. The fix changes the key to include the exam name, so every dropdown is fully unmounted and remounted on exam change and begins from a completely blank state.

## Changes

In components/dropdown.js, options.find() now falls back to null instead of returning undefined when no match is found. This is a two-character addition that makes react-select reliably clear its displayed value.

In pages/index.js, the renderFormCard call inside renderFields now passes selectedExam-field.name as the key instead of just field.name. This guarantees a fresh component instance for every field whenever the student picks a different exam.

## Why this approach

Both fixes are minimal and targeted. There is no restructuring of the form state or the exam config. The null fallback is the documented way to clear a react-select value. The key change is the standard React pattern for forcing a component to reset. Neither change affects any other part of the form.