### PR TITLE
feat: establish NeonDB pipeline and migrate JoSAA counselling data

### DIFF
--- a/DB/connection.js
+++ b/DB/connection.js
@@ -1,0 +1,17 @@
+import { Pool } from "pg"
+import { DB_URL } from "../utils/env_values.js";
+
+if (!DB_URL) {
+    throw new Error("Database URL is not defined. Check NEON_DB_URL in .env.local and env_values.js path resolution.");
+}
+
+console.log("DB_URL loaded:", DB_URL);
+
+const sslConfig = DB_URL.includes("sslmode=require") || DB_URL.includes("sslmode=verify-full") || DB_URL.includes("sslmode=prefer")
+    ? { rejectUnauthorized: false }
+    : false;
+
+export const pool = new Pool({
+    connectionString: DB_URL,
+    ssl: sslConfig,
+});

--- a/DB/db-migration/josaa.mjs
+++ b/DB/db-migration/josaa.mjs
@@ -1,0 +1,234 @@
+import fs from "fs";
+import path from "path";
+import { pool } from "../connection.js";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+const FILE_PATH = path.join(__dirname, "../../public/data/JEE/EWS (PwD).json")
+const raw = fs.readFileSync(FILE_PATH, "utf-8");
+
+const data = JSON.parse(raw);
+const LOG_FILE = path.join(__dirname, "../../logs/db-logs/insertion.log")
+// fs.appendFileSync(LOG_FILE, "TESTING >>>>")
+
+const logChanges = async (status, message, filePath = null, index = null) => {
+
+    const logEntry = {
+        timestamp: new Date().toISOString(),
+        status: status,
+        message: message,
+        record_index: index,
+        filePath: String(filePath),
+    };
+
+    fs.appendFileSync(
+        LOG_FILE,
+        JSON.stringify(logEntry) + "\n",
+        "utf-8"
+    );
+
+    return
+}
+
+
+const normalizeText = (value) => {
+    if (!value) return null;
+
+    return value.trim();
+};
+
+const toInt = (value) => {
+    if (value === null || value === undefined || value === "") {
+        return null;
+    }
+
+    return parseInt(value);
+};
+
+const toFloat = (value) => {
+    if (value === null || value === undefined || value === "") {
+        return null;
+    }
+
+    return parseFloat(value);
+};
+
+
+// FUNCTION TO EITHER GET THE ID IF EXISTS OR CREATE & INSERT THE ROW AND GET THE ID
+async function getOrCreate({
+    table,
+    DBfield,
+    value,
+    extraFields = {}
+}) {
+
+    if (!value) return null;
+
+    // TO AVOID ANY REPETATION OF VALUE
+    const existing = await pool.query(
+        `
+        SELECT id
+        FROM ${table}
+        WHERE ${DBfield} = $1
+        LIMIT 1
+        `,
+        [value]
+    );
+    if (existing.rows.length > 0) {
+        // IT EXISTS , RETURN THE ID
+        return existing.rows[0].id;
+    }
+
+    const fields = [
+        DBfield,
+        ...Object.keys(extraFields)
+    ];
+
+    const values = [
+        value,
+        ...Object.values(extraFields)
+    ];
+
+    const placeholders = values.map(
+        (_, i) => `$${i + 1}`
+    );
+
+    // INSERT THE NEW ROW
+    const inserted = await pool.query(
+        `
+    INSERT INTO ${table}
+    (${fields.join(", ")})
+    VALUES (${placeholders.join(", ")})
+    RETURNING id
+    `,
+        values
+    );
+
+    return inserted.rows[0].id;
+}
+
+
+async function importJosaa() {
+    logChanges("SUCCESS", "JoSAA import started")
+    let i = -1
+    for (const row of data) {
+        i++
+        try {
+            // CHECKING FOR UNIQUE VALUES
+            const examId = await getOrCreate({
+                table: "exams",
+                DBfield: "exam_name",
+                value: normalizeText(row["Exam"])
+            });
+
+            const quotaId = await getOrCreate({
+                table: "quotas",
+                DBfield: "quota_name",
+                value: normalizeText(row["Quota"])
+            });
+
+            const genderId = await getOrCreate({
+                table: "genders",
+                DBfield: "gender_name",
+                value: normalizeText(row["Gender"])
+            });
+
+            const category_id = await getOrCreate({
+                table: "categories",
+                DBfield: "category_name",
+                value: path.parse(FILE_PATH).name
+            });
+
+            const rankID = await getOrCreate({
+                table: "clg_rank",
+                DBfield: "af_hierarchy",
+                value: row["AF Hierarchy"]
+            });
+
+            const collegeId = await getOrCreate({
+                table: "colleges",
+                DBfield: "college_name",
+                value: normalizeText(row["Institute"]),
+                extraFields: {
+                    aishe_code: normalizeText(row["College ID"]),
+                    state: normalizeText(row["State"]),
+                    college_type: normalizeText(row["College Type"]),
+                    managed_by: normalizeText(row["Management Type"])
+                    // af_hierarchy: toFloat(row["AF Hierarchy"])
+                }
+            });
+
+            const courseId = await getOrCreate({
+                table: "courses",
+                DBfield: "course_name",
+                value: normalizeText(row["Academic Program Name"]),
+                extraFields: {
+                    program_name: "Engineering"
+                }
+            });
+
+            // INSERTING TO DEDICATED CUTOFF TABLE
+            await pool.query(
+                `
+        INSERT INTO josaa_cutoffs (
+          college_id,
+          course_id,
+          exam_id,
+          quota_id,
+          gender_id,
+          opening_rank,
+          closing_rank,
+          seat_type,
+          expected_salary,
+          salary_tier,
+          category_id,
+          rank_id
+        )
+        VALUES (
+          $1,$2,$3,$4,$5,
+          $6,$7,$8,$9,$10,$11,$12
+        )
+        `,
+                [
+                    collegeId,
+                    courseId,
+                    examId,
+                    quotaId,
+                    genderId,
+
+                    toInt(row["Opening Rank"]),
+                    toInt(row["Closing Rank"]),
+
+                    normalizeText(row["Seat Type"]),
+
+                    toFloat(row["Expected Salary"]),
+                    toInt(row["Salary Tier"]),
+
+                    category_id,
+                    rankID
+                ]
+            );
+
+            console.log(
+                `Inserted: ${row["Institute"]}`
+            );
+
+        } catch (err) {
+
+            logChanges("ERROR", err, FILE_PATH, i)
+
+            console.log(
+                `Failed: ${row["Institute"]}`
+            );
+
+            console.error(err);
+        }
+    }
+
+    logChanges("SUCCESS", "JoSAA import completed")
+    console.log("JoSAA import completed");
+}
+
+importJosaa();

--- a/DB/running_db.js
+++ b/DB/running_db.js
@@ -1,0 +1,12 @@
+import { cuttoffs_db } from "./schemas/cuttoffs_tables.js";
+import { masterDB } from "./schemas/master_tables.js";
+
+console.log("Task Execution Started")
+
+async function main() {
+    await masterDB();
+    await cuttoffs_db();
+    console.log("Task Successfully Executed");
+}
+
+main();

--- a/DB/schemas/cutoffs_tables.js
+++ b/DB/schemas/cutoffs_tables.js
@@ -1,0 +1,87 @@
+import { pool } from "../connection.js";
+
+export const cuttoffs_db = async () => {
+
+    await pool.query(`
+CREATE TABLE IF NOT EXISTS josaa_cutoffs (
+
+  id SERIAL PRIMARY KEY,
+
+  college_id INT NOT NULL
+  REFERENCES colleges(id)
+  ON DELETE CASCADE,
+
+  course_id INT NOT NULL
+  REFERENCES courses(id)
+  ON DELETE CASCADE,
+
+  exam_id INT NOT NULL
+  REFERENCES exams(id)
+  ON DELETE CASCADE,
+
+  quota_id INT
+  REFERENCES quotas(id)
+  ON DELETE SET NULL,
+
+  gender_id INT
+  REFERENCES genders(id)
+  ON DELETE SET NULL,
+
+  category_id INT
+  REFERENCES categories(id)
+  ON DELETE SET NULL,
+
+  rank_id INT
+  REFERENCES clg_rank(id)
+  ON DELETE SET NULL,
+
+  opening_rank INT,
+
+  closing_rank INT,
+
+  seat_type TEXT,
+
+  expected_salary FLOAT,
+
+  salary_tier INT
+);
+`);
+
+    await pool.query(`
+CREATE INDEX IF NOT EXISTS idx_josaa_cutoffs_college_id
+ON josaa_cutoffs(college_id);
+`);
+
+    await pool.query(`
+CREATE INDEX IF NOT EXISTS idx_josaa_cutoffs_course_id
+ON josaa_cutoffs(course_id);
+`);
+
+    await pool.query(`
+CREATE INDEX IF NOT EXISTS idx_josaa_cutoffs_exam_id
+ON josaa_cutoffs(exam_id);
+`);
+
+    await pool.query(`
+CREATE INDEX IF NOT EXISTS idx_josaa_cutoffs_quota_id
+ON josaa_cutoffs(quota_id);
+`);
+
+    await pool.query(`
+CREATE INDEX IF NOT EXISTS idx_josaa_cutoffs_gender_id
+ON josaa_cutoffs(gender_id);
+`);
+
+    await pool.query(`
+CREATE INDEX IF NOT EXISTS idx_josaa_cutoffs_category_id
+ON josaa_cutoffs(category_id);
+`);
+
+    await pool.query(`
+CREATE INDEX IF NOT EXISTS idx_josaa_cutoffs_rank_id
+ON josaa_cutoffs(rank_id);
+`);
+
+}
+
+cuttoffs_db()

--- a/DB/schemas/master_tables.js
+++ b/DB/schemas/master_tables.js
@@ -1,0 +1,106 @@
+import { pool } from "../connection.js";
+import { DB_URL } from "../../utils/env_values.js";
+
+export const masterDB = async () => {
+
+    console.log(pool, DB_URL)
+
+    await pool.query(
+        `CREATE TABLE IF NOT EXISTS colleges (
+  id SERIAL PRIMARY KEY,
+
+  external_college_id TEXT,
+
+  aishe_code TEXT,
+
+  college_name TEXT NOT NULL,
+
+  college_type TEXT,
+
+  managed_by TEXT,
+
+  year_of_establish INT,
+
+  district TEXT,
+
+  state TEXT,
+
+  region TEXT,
+
+  place TEXT,
+
+  dist_code TEXT,
+
+  co_ed TEXT,
+
+  UNIQUE(college_name, state)
+    );`
+    )
+
+    await pool.query(
+        `CREATE TABLE IF NOT EXISTS clg_rank (
+    id SERIAL PRIMARY KEY,
+    college_id INT REFERENCES colleges(id),
+    af_hierarchy TEXT,
+      nirf_ranking TEXT,
+      college_rank TEXT
+    );`
+    )
+
+    await pool.query(
+        ` CREATE TABLE IF NOT EXISTS exams (
+      id SERIAL PRIMARY KEY,
+      exam_name VARCHAR UNIQUE NOT NULL
+    );`
+    )
+
+    await pool.query(
+        `CREATE TABLE IF NOT EXISTS categories(
+        id SERIAL PRIMARY KEY,
+        category_name TEXT UNIQUE NOT NULL
+    );`
+    )
+
+    await pool.query(
+        `CREATE TABLE IF NOT EXISTS quotas (
+    id SERIAL PRIMARY KEY,
+    quota_name TEXT UNIQUE NOT NULL
+    );`
+    )
+
+    await pool.query(
+        `CREATE TABLE IF NOT EXISTS genders (
+    id SERIAL PRIMARY KEY,
+    gender_name TEXT UNIQUE NOT NULL
+    );`
+    )
+
+    await pool.query(
+        `CREATE TABLE IF NOT EXISTS courses (
+  id SERIAL PRIMARY KEY,
+
+  course_name TEXT NOT NULL,
+
+  program_name TEXT,
+
+  UNIQUE(course_name, program_name)
+    );`
+    )
+
+    await pool.query(`
+CREATE INDEX IF NOT EXISTS idx_college_name
+ON colleges(college_name);
+`);
+
+    await pool.query(`
+CREATE INDEX IF NOT EXISTS idx_course_name
+ON courses(course_name);
+`);
+
+    await pool.query(`
+CREATE INDEX IF NOT EXISTS idx_category_name
+ON categories(category_name);
+`);
+}
+
+masterDB()

--- a/utils/env_values.js
+++ b/utils/env_values.js
@@ -1,0 +1,9 @@
+import dotenv from "dotenv"
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+dotenv.config({ path: path.resolve(__dirname, "../.env.local") });
+
+export const DB_URL = process.env.NEON_DB_URL;


### PR DESCRIPTION
## Description
This PR introduces the initial PostgreSQL (**NeonDB**) integration layer along with a normalized relational schema for storing and querying counselling datasets, starting with JoSAA data migration.

The primary goal of this PR is to establish a scalable and extensible database foundation for future counselling dataset integrations and prediction workflows.

The implementation includes:
- NeonDB connectivity
- normalized relational schema design
- master entity tables
- JoSAA cutoff schema
- foreign-key based relational mappings
- optimized indexing for filtering and querying
- JSON-to-database migration pipeline

The schema architecture was iteratively redesigned during migration for better reliability among different counselling datasets.

## Problem
Earlier, the data for college prediction was fetched directly from raw datasets embedded within the codebase. The datasets were segregated across multiple directories and folders based on counselling exams.

While analyzing the datasets for database migration, I observed that several entities contained heavily repeated values across thousands of records. 

A good example can be JEE :
```
- institutes
- academic programs
- quotas
- genders
- categories
```

These entities inherently shared relationships with counselling cutoff data, but there was no relational database layer to formally establish and manage these connections.
As a result, identical values were repeatedly stored across records, leading to unnecessary redundancy and making the overall architecture difficult to scale efficiently for future counselling dataset integrations.

## Solution

**_1. Built NeonDB connection 
2. Designed relational database schema
3. Successfully migrated JoSAA data into PostgreSQL tables_**

Initially, I designed the schema around a simpler hierarchical structure :

<img width="1601" height="667" alt="Database-Schema" src="https://github.com/user-attachments/assets/5ca710b8-719f-4732-beaa-0b256a0bd8d9" />

This schema was initially designed into a normalized relational schema by separating reusable entities such as colleges, categories, and genders and storing into independent tables connected through foreign-key relationships with cuttoffs table. It worked great initially, the schema felt easy to understand and workable , but as I started migrating data inside the tables, I started identifying scalability issues caused by differences in dataset structures.

For example - Between Tseapert and JEE dataset
```
Tseapert data example : 
{
    "inst_code": "AARM",
    "institute_name": "AAR MAHAVEER ENGINEERING COLLEGE",
    "place": "BANDLAGUDA",
    "dist_code": "HYD",
    "co_ed": "COED",
    "college_type": "PVT",
    "year_of_establish": "2010.0",
    "branch_code": "CSE",
    "branch_name": "COMPUTER SCIENCE AND ENGINEERING",
    "category": "OC",
    "gender": "Male",
    "region": "other",
    "closing_rank": "29938",
    "tuition_fee": 60000.0,
    "affiliated_to": "JNTUH"
  }

JEE data example : 
{
        "College ID": "U-0306",
        "Institute": "Indian Institute Of Technology Bombay",
        "Academic Program Name": "Computer Science and Engineering (4 Years, Bachelor of Technology)",
        "AF Hierarchy": 1.0,
        "State": "Maharashtra",
        "Seat Type": "EWS (PwD)",
        "Gender": "Gender-Neutral",
        "Quota": "AI",
        "Closing Rank": "3",
        "Opening Rank": "3",
        "College Type": "Gen 1 IIT",
        "Management Type": "IIT\/NIT\/IIIT - Government Funded Technical Institute",
        "Expected Salary": 1880000.0,
        "Salary Tier": 1.0,
        "Exam": "JEE Advanced"
}
```
The **TSEAPCET** dataset contains fields like "year_of_establish" but does not include fields such as "Quota", whereas the **JEE** dataset contains "Quota" field but does not contain "year_of_establish"
This mismatch in dataset structures resulted in several columns containing NULL values when attempting to fit all datasets into a single generalized cutoff schema.

_To solve this, I redesigned the schema architecture_

## Current Schema Design
<img width="1330" height="756" alt="Screenshot 2026-05-14 221519" src="https://github.com/user-attachments/assets/2aa24590-9c9b-4d2d-a603-055c2908c2d9" />


Designed the architecture into a more modular and normalized relational schema.
Instead of forcing every counselling dataset into a single generalized table, the new design separates reusable entities into master tables and counselling-specific information into dedicated cutoff tables.

The new structure introduces independent master tables for all the unique fields within the entities.
And for every counselling exam, a dedicated cutoff table is created with fields specific to that dataset, preventing unnecessary **NULL** values and making the schema more **modular, scalable, and maintainable.**

This architecture also improves:
- relational consistency
- query optimization
- ETL workflow scalability
- future multi-exam integration support

Most importantly, the architecture now scales naturally with structurally different counselling datasets without requiring major schema rewrites. New datasets can be integrated independently while still sharing common relational entities through foreign-key mappings, making the overall system significantly more maintainable, extensible, and production-ready for future prediction and counselling workflows.

## RUN GUIDE 
```
# Create .env.local
NEON_DB_URL = 

# Create schema
cd DB
node running_db.js

# Run JoSAA migration
cd db-migration
node josaa.mjs
```