### PR TITLE
fix: resolve filter bugs causing zero results for JEE Main-JOSAA and …

### DIFF
--- a/examConfig.js
+++ b/examConfig.js
@@ -8,7 +8,7 @@ import path from "path";
 
 /**
  * Example URL with query parameters for JEE Main-JOSAA
- *  http://futures.avantifellow.com/api/exam-result?exam=JEE%20Main&roundNumber=2&gender=Female-only%20(including%20Supernumerary)&homeState=Karnataka&category=obc_ncl
+ *  http://futures.avantifellow.com/api/exam-result?exam=JEE%20Main-JOSAA&gender=Female-only%20(including%20Supernumerary)&homeState=Karnataka&category=obc_ncl
  */
 
 export const statesList = [
@@ -139,7 +139,7 @@ export const jeeMainJosaaConfig = {
   getFilters: (query) => {
     const normalizedProgram = String(query.program || "").toLowerCase();
     const baseFilters = [
-      (item) => item.Exam === query.code,
+      (item) => item.Exam === "JEE Main",
       (item) => item.Gender === query.gender,
       (item) => {
         if (normalizedProgram === "architecture") {
@@ -240,7 +240,7 @@ export const jacExamConfig = {
     (item) => item.PWD === query.isPWD,
     (item) => item.Gender === query.gender,
     (item) =>
-      parseInt(item["Closing Rank"], 10) > 0.9 * parseInt(query.rank, 10),
+      parseInt(item["Closing Rank"], 10) >= 0.9 * parseInt(query.rank, 10),
   ],
   getSort: () => [["Closing Rank", "ASC"]],
 };
@@ -297,7 +297,7 @@ export const jeeAdvancedConfig = {
   },
   getFilters: (query) => {
     const baseFilters = [
-      (item) => item.Exam === query.code,
+      (item) => item.Exam === "JEE Advanced",
       (item) => item.Gender === query.gender,
     ];
 

--- a/pages/api/exam-result.js
+++ b/pages/api/exam-result.js
@@ -203,9 +203,9 @@ export default async function handler(req, res) {
         }
       } else if (exam === "JEE Advanced") {
         if (item["Exam"] !== "JEE Advanced") return false;
-        if (!req.query.advRank) return false;
+        if (!req.query.rank) return false;
 
-        const userRankStr = req.query.advRank?.toString().trim() || "";
+        const userRankStr = req.query.rank?.toString().trim() || "";
         const userRank = parseRank(userRankStr);
         const userHasPSuffix = hasPSuffix(userRankStr);
 


### PR DESCRIPTION
…JEE Advanced

- Replace query.code (always undefined) with literal exam codes in jeeMainJosaaConfig and jeeAdvancedConfig getFilters — fixes zero results for both exams
- Fix JEE Advanced rankFilter reading req.query.advRank (JoSAA-only param) instead of req.query.rank — fixes zero results for standalone JEE Advanced queries
- Change JAC closing rank filter from > to >= to match documented behaviour (>= 90% of user rank)
- Fix example URL in comment: exam=JEE Main → exam=JEE Main-JOSAA