### PR TITLE
feat: implement reusable SeoHead component with OG tags

### DIFF
--- a/components/SeoHead.js
+++ b/components/SeoHead.js
@@ -1,0 +1,55 @@
+import Head from "next/head";
+import PropTypes from "prop-types";
+
+/**
+ * Reusable SEO component for standardizing meta tags across the application.
+ * Follows Open Graph and Twitter Card standards for rich social previews.
+ */
+const SeoHead = ({ title, description, keywords, ogImage, ogUrl }) => {
+  const siteName = "Avanti Fellows College Predictor";
+  const defaultDescription =
+    "Predict your college admissions based on your ranks in JEE, JoSAA, TNEA, and more with Avanti Fellows College Predictor.";
+  const defaultKeywords =
+    "College Predictor, JEE Main, JEE Advanced, JoSAA, TNEA, Avanti Fellows, Engineering Admissions, India";
+  const defaultImage = "https://cdn.avantifellows.org/af_logos/avanti_logo_black_text.webp";
+  const baseUrl = "https://college-predictor.avantifellows.org"; // Ensure this is the correct production domain if possible
+
+  const metaTitle = title || siteName;
+  const metaDescription = description || defaultDescription;
+  const metaKeywords = keywords || defaultKeywords;
+  const metaImage = ogImage || defaultImage;
+  const metaUrl = ogUrl || baseUrl;
+
+  return (
+    <Head>
+      <title>{metaTitle}</title>
+      <meta name="description" content={metaDescription} />
+      <meta name="keywords" content={metaKeywords} />
+
+      {/* Open Graph / Facebook */}
+      <meta property="og:type" content="website" />
+      <meta property="og:url" content={metaUrl} />
+      <meta property="og:title" content={metaTitle} />
+      <meta property="og:description" content={metaDescription} />
+      <meta property="og:image" content={metaImage} />
+      <meta property="og:site_name" content={siteName} />
+
+      {/* Twitter */}
+      <meta name="twitter:card" content="summary_large_image" />
+      <meta name="twitter:url" content={metaUrl} />
+      <meta name="twitter:title" content={metaTitle} />
+      <meta name="twitter:description" content={metaDescription} />
+      <meta name="twitter:image" content={metaImage} />
+    </Head>
+  );
+};
+
+SeoHead.propTypes = {
+  title: PropTypes.string,
+  description: PropTypes.string,
+  keywords: PropTypes.string,
+  ogImage: PropTypes.string,
+  ogUrl: PropTypes.string,
+};
+
+export default SeoHead;

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -1,10 +1,12 @@
 import Head from "next/head";
 import Layout from "../components/Layout";
+import SeoHead from "../components/SeoHead";
 import "../styles/globals.css";
 
 function MyApp({ Component, pageProps }) {
   return (
     <>
+      <SeoHead />
       <Head>
         <link rel="icon" href="/favicon.ico" />
       </Head>

--- a/pages/batch-predict.js
+++ b/pages/batch-predict.js
@@ -1,4 +1,4 @@
-import Head from "next/head";
+import SeoHead from "../components/SeoHead";
 import React, { useMemo, useState } from "react";
 import { AlertCircle, Download, FileSpreadsheet, Upload } from "lucide-react";
 
@@ -172,9 +172,10 @@ const BatchPredict = () => {
 
   return (
     <>
-      <Head>
-        <title>Batch Predictor</title>
-      </Head>
+      <SeoHead 
+        title="Batch Predictor | Avanti Fellows" 
+        description="Upload a CSV to generate batch college predictions for multiple students."
+      />
       <div className="flex min-h-[calc(100vh-120px)] flex-col">
         <div className="mt-6 flex w-full flex-col items-center justify-start px-4 pb-10 sm:mt-8">
           <div className="mt-4 flex w-full max-w-3xl flex-col rounded-2xl border border-[#eaded8] bg-white p-5 shadow-sm sm:mt-6 sm:p-6">

--- a/pages/college_predictor.js
+++ b/pages/college_predictor.js
@@ -2,7 +2,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import { useRouter } from "next/router";
 import getConstants from "../constants";
 import PredictedCollegeTables from "../components/PredictedCollegeTables";
-import Head from "next/head";
+import SeoHead from "../components/SeoHead";
 import Fuse from "fuse.js";
 import examConfigs from "../examConfig";
 import dynamic from "next/dynamic";
@@ -1021,9 +1021,10 @@ const CollegePredictor = () => {
 
   return (
     <>
-      <Head>
-        <title>College Predictor Results - {getConstants().TITLE_SHORT}</title>
-      </Head>
+      <SeoHead 
+        title={`College Predictor Results - ${getConstants().TITLE_SHORT}`} 
+        description="View your predicted colleges based on your exam scores and ranks." 
+      />
       <div className="min-h-screen bg-[#fdf8f6] flex flex-col items-center pt-8 px-4">
         <div className="w-full max-w-6xl rounded-2xl border border-[#eaded8] bg-white p-6 shadow-sm md:p-8">
           <h1 className="mb-2 text-center text-2xl font-bold text-[#2f2320] sm:text-3xl">

--- a/pages/index.js
+++ b/pages/index.js
@@ -3,7 +3,7 @@ import Script from "next/script";
 import getConstants from "../constants";
 import examConfigs from "../examConfig";
 import { useRouter } from "next/router";
-import Head from "next/head";
+import SeoHead from "../components/SeoHead";
 import dynamic from "next/dynamic";
 import TneaScoreCalculator from "../components/TneaScoreCalculator";
 import { ExternalLink, PlayCircle } from "lucide-react";
@@ -540,9 +540,10 @@ const ExamForm = () => {
 
   return (
     <>
-      <Head>
-        <title>College Predictor - Home</title>
-      </Head>
+      <SeoHead 
+        title="College Predictor - Home | Avanti Fellows" 
+        description="Predict your college admissions based on your ranks in JEE, JoSAA, TNEA, and more with Avanti Fellows College Predictor." 
+      />
       <div className="flex min-h-[calc(100vh-120px)] flex-col">
         <div className="mt-6 flex w-full flex-col items-center justify-start px-4 pb-10 sm:mt-8">
           <Script

--- a/pages/scholarships.js
+++ b/pages/scholarships.js
@@ -1,12 +1,13 @@
-import Head from "next/head";
+import SeoHead from "../components/SeoHead";
 import ScholarshipReferenceBrowser from "../components/ScholarshipReferenceBrowser";
 
 const ScholarshipsPage = () => {
   return (
     <>
-      <Head>
-        <title>Scholarships Reference - Home</title>
-      </Head>
+      <SeoHead 
+        title="Scholarships Reference - Home | Avanti Fellows" 
+        description="Explore various scholarships available for students." 
+      />
       <ScholarshipReferenceBrowser />
     </>
   );

--- a/pages/scholarships_result.js
+++ b/pages/scholarships_result.js
@@ -1,12 +1,13 @@
-import Head from "next/head";
+import SeoHead from "../components/SeoHead";
 import ScholarshipReferenceBrowser from "../components/ScholarshipReferenceBrowser";
 
 const ScholarshipsResultPage = () => {
   return (
     <>
-      <Head>
-        <title>Scholarships Reference - Home</title>
-      </Head>
+      <SeoHead 
+        title="Scholarships Results | Avanti Fellows" 
+        description="View scholarships applicable to your profile." 
+      />
       <ScholarshipReferenceBrowser />
     </>
   );


### PR DESCRIPTION
What does this PR do?
This PR introduces a reusable <SeoHead> component to improve the application's Search Engine Optimization (SEO) and social media link previews (Open Graph & Twitter Cards). It replaces the basic Next.js <Head> tags across all major pages with this unified component.

Why is this change necessary?
Previously, the application lacked proper Open Graph (OG) tags and comprehensive meta descriptions. This meant that when links were shared on platforms like WhatsApp, LinkedIn, or Twitter, they did not render rich preview cards (with titles, descriptions, and banners). This PR ensures that all pages dynamically inject these tags, making the Avanti College Predictor more discoverable and shareable.

Key Changes:
Created components/SeoHead.js: A reusable Next.js Head wrapper with default fallbacks for Avanti Fellows branding.
Updated pages/_app.js: Added a global <SeoHead> fallback to ensure 100% SEO coverage.
Updated pages/index.js, college_predictor.js, scholarships.js, scholarships_result.js, and batch-predict.js: Replaced hardcoded basic <Head> elements with the new <SeoHead> component, passing page-specific titles and descriptions.
Type of change:
 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Breaking change (fix or feature that would cause existing functionality to not work as expected)
 Documentation Update
Checklist:
 My code follows the style guidelines of this project.
 I have performed a self-review of my own code.
 I have commented my code, particularly in hard-to-understand areas (SeoHead component).
 I have successfully run npm run build locally and it compiles without errors.
Fixes: #293 