### PR TITLE
fix: apply cutoff score filter for GUJCET predictor results

### DIFF
--- a/examConfig.js
+++ b/examConfig.js
@@ -1038,6 +1038,16 @@ export const gujcetConfig = {
         }
         return true;
       },
+      (item) => {
+        if (query.rank) {
+          const closingMarks = parseFloat(item.closing_marks);
+          const userScore = parseFloat(query.rank);
+          if (!isNaN(closingMarks) && !isNaN(userScore)) {
+            return userScore >= closingMarks;
+          }
+        }
+        return true;
+      },
     ];
   },
   getSort: () => [["closing_marks", "DESC"]], // Sort by closing_marks in descending order


### PR DESCRIPTION
Before this fix, the GUJCET predictor returned all colleges regardless of the student's percentage score. The getFilters function only filtered by category and program but completely ignored the student's input score.

A student entering 78% and a student entering 20% would both see the exact same list of colleges, making the score input meaningless.

Fix: Add a closing_marks filter that only includes colleges where the student's score is greater than or equal to the college's cutoff percentage. This matches how other exams in the codebase handle rank filtering.

GUJCET uses percentage scores where a higher closing_marks means a harder cutoff, so the student must score >= the closing_marks to be eligible. 

Fixes this for both category and program filter combinations.

<img width="1916" height="964" alt="image" src="https://github.com/user-attachments/assets/00d7f623-73bb-4b61-9863-32492eaa0c5f" />

Closes #303 