### PR TITLE
Add JoSAA Mock Allotment — practice choice-filling with real 2025 cutoff data

### DIFF
--- a/components/MockAllotment.js
+++ b/components/MockAllotment.js
@@ -9,7 +9,6 @@ import {
   getRoundOneResult,
   advanceRound,
   findMissedBetterOptions,
-  findIndicativeRank,
   TOTAL_ROUNDS,
 } from "../utils/josaaSimulator";
 
@@ -252,8 +251,6 @@ const MockAllotment = () => {
 
   const lockChoices = () =>
     setState((s) => ({ ...s, locked: true, trail: [], frozen: false, step: "simulate" }));
-  const unlock = () =>
-    setState((s) => ({ ...s, locked: false, trail: [], frozen: false, step: "choices" }));
 
   const freeze = () => setState((s) => ({ ...s, frozen: true }));
 
@@ -273,6 +270,19 @@ const MockAllotment = () => {
       );
       return { ...s, trail: [...s.trail, next] };
     });
+  };
+
+  // Real JoSAA rounds don't resolve instantly — this fakes that processing
+  // feel (and gives round-to-round changes a beat to register) by holding a
+  // label on screen for a bit before actually applying the state change.
+  // No real async work happens here; it's purely cosmetic pacing.
+  const [transitionLabel, setTransitionLabel] = useState(null);
+  const runWithDelay = (label, delayMs, action) => {
+    setTransitionLabel(label);
+    window.setTimeout(() => {
+      action();
+      setTransitionLabel(null);
+    }, delayMs);
   };
 
   const restart = () => {
@@ -298,13 +308,14 @@ const MockAllotment = () => {
         JoSAA Mock Allotment
       </h1>
       <p className="mt-1 text-sm text-[#7a655f]">
-        Practice choice-filling, locking, and the freeze/float rounds using real
-        JoSAA 2025 cutoff data — a training tool, not the real counselling.
+        Practice choice-filling and the freeze/float rounds with real JoSAA 2025 cutoff data.
       </p>
 
       <StepBar current={state.step} locked={state.locked} onSelect={setStep} />
 
-      {state.step === "info" && (
+      {transitionLabel && <LoadingCard label={transitionLabel} />}
+
+      {!transitionLabel && state.step === "info" && (
         <InfoStep
           profile={state.profile}
           setProfile={setProfile}
@@ -313,7 +324,7 @@ const MockAllotment = () => {
         />
       )}
 
-      {state.step === "choices" && (
+      {!transitionLabel && state.step === "choices" && (
         <ChoicesStep
           loading={dataLoading}
           error={dataError}
@@ -336,18 +347,22 @@ const MockAllotment = () => {
           onMoveToPosition={moveChoiceToPosition}
           onBack={() => setStep("info")}
           onNext={() => setStep("review")}
+          locked={state.locked}
         />
       )}
 
-      {state.step === "review" && (
+      {!transitionLabel && state.step === "review" && (
         <ReviewStep
           profile={state.profile}
           choices={state.choices}
           locked={state.locked}
           onBack={() => setStep("choices")}
-          onLock={lockChoices}
-          onUnlock={unlock}
-          onProceed={() => setStep("simulate")}
+          onLock={() =>
+            runWithDelay("Locking your choices and running Round 1 allotment…", 1400, lockChoices)
+          }
+          onProceed={() =>
+            runWithDelay("Returning to your simulation…", 700, () => setStep("simulate"))
+          }
           onReorder={reorderChoices}
           onMoveUp={moveChoiceUp}
           onMoveDown={moveChoiceDown}
@@ -356,7 +371,7 @@ const MockAllotment = () => {
         />
       )}
 
-      {state.step === "simulate" && (
+      {!transitionLabel && state.step === "simulate" && (
         <SimulateStep
           locked={state.locked}
           choices={state.choices}
@@ -367,8 +382,13 @@ const MockAllotment = () => {
           missedOptions={missedOptions}
           collegesByName={collegesByName}
           onFreeze={freeze}
-          onAdvance={advance}
-          onUnlock={unlock}
+          onAdvance={(mode) =>
+            runWithDelay(
+              `Processing Round ${current ? current.round + 1 : ""} allotment…`,
+              1100,
+              () => advance(mode)
+            )
+          }
           onRestart={restart}
         />
       )}
@@ -396,6 +416,18 @@ const StepBar = ({ current, locked, onSelect }) => (
         </button>
       );
     })}
+  </div>
+);
+
+// Shown in place of the current step while a locking/round action fakes a
+// beat of "processing" — see runWithDelay in MockAllotment.
+const LoadingCard = ({ label }) => (
+  <div className={`${cardClass} mt-6 flex flex-col items-center justify-center gap-3 py-14 text-center`}>
+    <div
+      className="h-9 w-9 animate-spin rounded-full border-4 border-[#f0e6e1] border-t-[#b52326]"
+      aria-hidden="true"
+    />
+    <p className="text-sm font-semibold text-[#5b4a45]">{label}</p>
   </div>
 );
 
@@ -493,12 +525,6 @@ const InfoStep = ({ profile, setProfile, onNext, valid }) => (
       )}
     </div>
 
-    <p className="mt-3 text-xs text-[#7a655f]">
-      Program type isn&apos;t asked here — you&apos;ll filter by Engineering /
-      Architecture / Planning while browsing choices, same as real JoSAA lets
-      you mix them in one list.
-    </p>
-
     <div className="mt-5 flex justify-end">
       <button type="button" className={primaryBtn} disabled={!valid} onClick={onNext}>
         Continue to Choice Filling →
@@ -507,7 +533,7 @@ const InfoStep = ({ profile, setProfile, onNext, valid }) => (
   </div>
 );
 
-const CatalogRow = ({ item, added, onAdd }) => (
+const CatalogRow = ({ item, added, onAdd, locked }) => (
   <div className="flex items-center justify-between gap-3 border-b border-[#f0e6e1] px-3 py-2 last:border-b-0">
     <div className="min-w-0">
       <p className="text-sm font-semibold text-[#3a2c28]">{item.institute}</p>
@@ -515,19 +541,18 @@ const CatalogRow = ({ item, added, onAdd }) => (
       {/* Deliberately no cutoff/rank shown here — this is a practice mock, not
           the predictor. Seeing which seats are "easy" before you build your
           list defeats the point: real JoSAA doesn't tell you either. */}
-      <p className="mt-0.5 text-[11px] text-[#9a8a84]">Quota: {item.quota}</p>
     </div>
     <button
       type="button"
-      disabled={added}
+      disabled={added || locked}
       onClick={() => onAdd(item)}
       className={`shrink-0 rounded-full px-3 py-1 text-xs font-semibold transition ${
-        added
+        added || locked
           ? "cursor-not-allowed bg-[#f0e6e1] text-[#9a8a84]"
           : "bg-[#b52326] text-white hover:bg-[#98191c]"
       }`}
     >
-      {added ? "Added ✓" : "+ Add"}
+      {locked ? "Locked" : added ? "Added ✓" : "+ Add"}
     </button>
   </div>
 );
@@ -713,8 +738,14 @@ const ChoicesStep = ({
   onMoveToPosition,
   onBack,
   onNext,
+  locked,
 }) => (
   <div className="mt-6 grid gap-6 md:grid-cols-2">
+    {locked && (
+      <p className="md:col-span-2 rounded-xl border border-[#d8c7c1] bg-[#f8efec] px-4 py-2 text-xs font-semibold text-[#5b4a45]">
+        Choices are locked & submitted — browsing only, no changes.
+      </p>
+    )}
     <div className={cardClass}>
       <h2 className="text-sm font-bold text-[#3a2c28]">
         Browse choices {totalCatalogSize ? `(${totalCatalogSize} eligible for you)` : ""}
@@ -767,6 +798,7 @@ const ChoicesStep = ({
               item={item}
               added={chosenKeys.has(`${item.institute}|${item.program}`)}
               onAdd={onAdd}
+              locked={locked}
             />
           ))}
       </div>
@@ -777,10 +809,19 @@ const ChoicesStep = ({
         Your preference order ({choices.length})
       </h2>
       {choices.length === 0 ? (
-        <p className="mt-3 text-sm text-[#7a655f]">
-          Add choices from the left — drag, use ↑/↓, or type a position number to reorder them as
-          you go.
-        </p>
+        <p className="mt-3 text-sm text-[#7a655f]">Add choices from the left.</p>
+      ) : locked ? (
+        <ol className="mt-2 space-y-1">
+          {choices.map((item, index) => (
+            <li
+              key={`${item.institute}|${item.program}`}
+              className="rounded-lg border border-[#f0e6e1] px-3 py-2 text-sm"
+            >
+              <span className="mr-2 font-bold text-[#b52326]">{index + 1}.</span>
+              {item.institute} — <span className="text-[#7a655f]">{item.program}</span>
+            </li>
+          ))}
+        </ol>
       ) : (
         <ReorderableChoiceList
           choices={choices}
@@ -802,7 +843,7 @@ const ChoicesStep = ({
           disabled={choices.length === 0}
           onClick={onNext}
         >
-          Continue to Review →
+          {locked ? "Go to Review →" : "Save and Continue →"}
         </button>
       </div>
     </div>
@@ -815,14 +856,24 @@ const ReviewStep = ({
   locked,
   onBack,
   onLock,
-  onUnlock,
   onProceed,
   onReorder,
   onMoveUp,
   onMoveDown,
   onMoveToPosition,
   onRemove,
-}) => (
+}) => {
+  // Purely cosmetic confirmation — reordering/removing already saves to state
+  // (and localStorage) immediately, so this button has nothing extra to do
+  // except reassure the student their order stuck, the way JoSAA's own
+  // "Save" click does.
+  const [justSaved, setJustSaved] = useState(false);
+  const flashSaved = () => {
+    setJustSaved(true);
+    window.setTimeout(() => setJustSaved(false), 1500);
+  };
+
+  return (
   <div className={`${cardClass} mt-6`}>
     <h2 className="text-sm font-bold text-[#3a2c28]">Your profile</h2>
     <div className="mt-2 flex flex-wrap gap-2 text-xs text-[#5b4a45]">
@@ -848,10 +899,6 @@ const ReviewStep = ({
 
     {!locked ? (
       <>
-        <p className="mt-1 text-xs text-[#7a655f]">
-          Drag the grip, use the ↑/↓ buttons, or type a position number to reorder — #1 is your
-          top preference, same as JoSAA&apos;s own choice list.
-        </p>
         <ReorderableChoiceList
           choices={choices}
           onReorder={onReorder}
@@ -881,20 +928,28 @@ const ReviewStep = ({
           <button type="button" className={secondaryBtn} onClick={onBack}>
             ← Back to add more choices
           </button>
-          <button
-            type="button"
-            className={primaryBtn}
-            disabled={choices.length === 0}
-            onClick={onLock}
-          >
-            🔒 Lock My Choices
-          </button>
+          <div className="flex flex-wrap gap-2">
+            <button
+              type="button"
+              className={secondaryBtn}
+              disabled={choices.length === 0}
+              onClick={flashSaved}
+            >
+              {justSaved ? "✓ Saved" : "Save changes"}
+            </button>
+            <button
+              type="button"
+              className={primaryBtn}
+              disabled={choices.length === 0}
+              onClick={onLock}
+            >
+               Lock & Submit Choices
+            </button>
+          </div>
         </>
       ) : (
         <>
-          <button type="button" className={secondaryBtn} onClick={onUnlock}>
-            Unlock & edit choices
-          </button>
+          <p className="text-xs text-[#7a655f]">Locked & submitted.</p>
           <button type="button" className={primaryBtn} onClick={onProceed}>
             Proceed to Simulation →
           </button>
@@ -902,7 +957,8 @@ const ReviewStep = ({
       )}
     </div>
   </div>
-);
+  );
+};
 
 const RoundCard = ({ current, choicesCount }) => {
   if (!current) return null;
@@ -915,7 +971,7 @@ const RoundCard = ({ current, choicesCount }) => {
       </div>
     );
   }
-  const { choice, index, opening, closing, quota, gender } = current.provisional;
+  const { choice, index, opening, closing } = current.provisional;
   return (
     <div className={cardClass}>
       <p className="text-xs font-semibold uppercase tracking-wide text-[#b52326]">
@@ -924,8 +980,8 @@ const RoundCard = ({ current, choicesCount }) => {
       <p className="mt-1 text-lg font-bold text-[#3a2c28]">{choice.institute}</p>
       <p className="text-sm text-[#5b4a45]">{choice.program}</p>
       <p className="mt-2 text-xs text-[#7a655f]">
-        Your preference #{index + 1} of {choicesCount} · Quota {quota} · Pool {gender} · Opening{" "}
-        {formatRank(opening)} / Closing {formatRank(closing)}
+        Your preference #{index + 1} of {choicesCount} · Opening {formatRank(opening)} / Closing{" "}
+        {formatRank(closing)}
       </p>
     </div>
   );
@@ -935,17 +991,17 @@ const MISSED_OPTIONS_TABS = [
   {
     key: "closingRank",
     label: "By Closing Rank",
-    note: "Most reliable — the actual seat-level cutoff, with full coverage. JEE Main and JEE Advanced can't be ranked against each other on this number though (different candidate pools), so they're grouped separately below.",
+    note: "",
   },
   {
     key: "nirf",
     label: "By NIRF Ranking",
-    note: "College-level rank (not branch-level), and only about half of institutes are NIRF-ranked at all. Comparable across JEE Main and JEE Advanced institutes alike.",
+    note: "College-level, not branch-level — only ~half of institutes are ranked.",
   },
   {
     key: "salary",
-    label: "By Median Salary",
-    note: "This median is across ALL branches of the college, not this specific branch — the least reliable of the three. Closing rank is the most accurate comparison.",
+    label: "By Median CTC",
+    note: "College-wide median, not specific to this branch.",
   },
 ];
 
@@ -959,8 +1015,8 @@ const missedOptionRow = (opt) => (
     <p className="font-semibold text-[#3a2c28]">{opt.institute}</p>
     <p className="text-xs text-[#7a655f]">{opt.program}</p>
     <p className="mt-1 text-[11px] text-[#9a8a84]">
-      Closing rank: {formatRank(opt.closingRank)} · NIRF: {opt.nirfRank ?? "not ranked"} · Salary:{" "}
-      {formatSalary(opt.medianSalary)}
+      Closing rank: {formatRank(opt.closingRank)} · NIRF: {opt.nirfRank ?? "not ranked"} · Median
+      CTC: {formatSalary(opt.medianSalary)}
       {opt.listPosition != null && (
         <>
           {" "}
@@ -981,10 +1037,7 @@ const MissedOptionsPanel = ({ missedOptions, round }) => {
   return (
     <div className={cardClass}>
       <h2 className="text-sm font-bold text-[#3a2c28]">You may have gotten a better option</h2>
-      <p className="mt-1 text-xs text-[#7a655f]">
-        These were also reachable in Round {round} — some weren&apos;t in your list at all,
-        others you&apos;d ranked lower than what you got (flagged below).
-      </p>
+      <p className="mt-1 text-xs text-[#7a655f]">Also reachable in Round {round}:</p>
 
       <div className="mt-3 flex flex-wrap gap-1">
         {MISSED_OPTIONS_TABS.map((t) => (
@@ -1002,7 +1055,7 @@ const MissedOptionsPanel = ({ missedOptions, round }) => {
           </button>
         ))}
       </div>
-      <p className="mt-2 text-[11px] text-[#9a8a84]">{activeTab.note}</p>
+      {activeTab.note && <p className="mt-2 text-[11px] text-[#9a8a84]">{activeTab.note}</p>}
 
       {tab === "closingRank" && (
         <ClosingRankGroups missedOptions={missedOptions} />
@@ -1013,7 +1066,7 @@ const MissedOptionsPanel = ({ missedOptions, round }) => {
           metricKey={tab === "nirf" ? "nirfRank" : "medianSalary"}
           direction={tab === "nirf" ? "asc" : "desc"}
           emptyMessage={`None of the missed options have ${
-            tab === "nirf" ? "an NIRF rank" : "a salary figure"
+            tab === "nirf" ? "an NIRF rank" : "a CTC figure"
           } on record.`}
         />
       )}
@@ -1081,7 +1134,6 @@ const SimulateStep = ({
   collegesByName,
   onFreeze,
   onAdvance,
-  onUnlock,
   onRestart,
 }) => {
   if (!locked) {
@@ -1101,9 +1153,6 @@ const SimulateStep = ({
 
   const finalChoice = current.provisional;
   const college = finalChoice ? collegesByName?.get(finalChoice.choice.institute) : null;
-  const indicativeRank = finalChoice
-    ? findIndicativeRank(college, finalChoice.choice.program)
-    : null;
   const canSlide = Boolean(finalChoice);
 
   return (
@@ -1114,10 +1163,10 @@ const SimulateStep = ({
         {!finalRevealed && (
           <>
             <button type="button" className={primaryBtn} onClick={onFreeze}>
-              ❄️ Freeze this seat
+              Freeze this seat
             </button>
             <button type="button" className={secondaryBtn} onClick={() => onAdvance("float")}>
-              🔄 Float to Round {current.round + 1}
+              Float to Round {current.round + 1}
             </button>
             <button
               type="button"
@@ -1130,7 +1179,7 @@ const SimulateStep = ({
               className={secondaryBtn}
               onClick={() => onAdvance("slide")}
             >
-              ↕️ Slide to Round {current.round + 1}
+               Slide to Round {current.round + 1}
             </button>
           </>
         )}
@@ -1145,10 +1194,8 @@ const SimulateStep = ({
 
       {!finalRevealed && (
         <p className="text-[11px] text-[#9a8a84]">
-          <strong>Float</strong> checks your whole list for anything better — could be a
-          different institute. <strong>Slide</strong> only checks other branches at{" "}
-          {canSlide ? finalChoice.choice.institute : "your current institute"} — you keep the
-          college, only the branch can improve.
+          <strong>Float</strong>: checks your whole list. <strong>Slide</strong>: same institute,
+          other branches only.
         </p>
       )}
 
@@ -1177,11 +1224,15 @@ const SimulateStep = ({
             <span className="rounded-full bg-[#f8efec] px-3 py-1">
               NIRF Engg rank: {college?.nirf?.engineering_rank ?? "not ranked"}
             </span>
+            {/* Same opening/closing already shown in the round card above —
+                sourced from the same seat lookup (your actual quota/category/
+                round), not colleges.json's generic OPEN-category figure, so
+                it never disagrees with what you just saw. */}
             <span className="rounded-full bg-[#f8efec] px-3 py-1">
-              Branch indicative closing rank: {formatRank(indicativeRank)}
+              Branch closing rank (your quota): {formatRank(finalChoice.closing)}
             </span>
             <span className="rounded-full bg-[#f8efec] px-3 py-1">
-              Median salary (college-level): {formatSalary(college?.placement?.median_salary)}
+              Median CTC (college-level): {formatSalary(college?.placement?.median_salary)}
             </span>
           </div>
         </div>
@@ -1201,16 +1252,10 @@ const SimulateStep = ({
       )}
 
       <p className="text-[11px] text-[#9a8a84]">
-        Based on JoSAA 2025 cutoffs across all 6 rounds. This mock does not simulate other
-        candidates&apos; choices or real-time seat withdrawal — it checks, each round, whether
-        your listed seats&apos; actual closing rank that round would have covered your rank.
-        NIRF rank and salary are per-college, not per-branch.
+        Based on JoSAA 2025 cutoffs. NIRF rank and CTC are per-college, not per-branch.
       </p>
 
       <div className="flex flex-wrap gap-2">
-        <button type="button" className={secondaryBtn} onClick={onUnlock}>
-          Unlock & edit choices
-        </button>
         <button type="button" className={secondaryBtn} onClick={onRestart}>
           ↺ Restart mock allotment
         </button>

--- a/components/MockAllotment.js
+++ b/components/MockAllotment.js
@@ -1,0 +1,1222 @@
+import React, { useEffect, useMemo, useRef, useState } from "react";
+import { GripVertical } from "lucide-react";
+import { josaaConfig, statesList } from "../examConfig";
+import {
+  loadAllRoundsData,
+  loadCollegesData,
+  buildSeatIndex,
+  buildCatalog,
+  getRoundOneResult,
+  advanceRound,
+  findMissedBetterOptions,
+  findIndicativeRank,
+  TOTAL_ROUNDS,
+} from "../utils/josaaSimulator";
+
+// Practice JoSAA choice-filling + locking + a round-by-round freeze/float mock,
+// built entirely on data already in this repo (see docs/SIMULATION_DATA.md).
+// No backend: everything lives in component state + localStorage, mirroring
+// how the rest of this app has no database either.
+
+// v2: replaced the precomputed 6-round trace (roundPointer into it) with an
+// interactive trail, so freeze/float/slide can each change what's checked
+// next round instead of all 6 rounds being decided upfront.
+const STORAGE_KEY = "josaaMockAllotmentState_v2";
+
+const STEPS = ["info", "choices", "review", "simulate"];
+const STEP_LABELS = {
+  info: "1. Student Info",
+  choices: "2. Choice Filling",
+  review: "3. Review & Manage",
+  simulate: "4. Simulation",
+};
+
+const categoryField = josaaConfig.fields.find((f) => f.name === "category");
+const genderField = josaaConfig.fields.find((f) => f.name === "gender");
+const qualifiedField = josaaConfig.fields.find((f) => f.name === "qualifiedJeeAdv");
+
+const optionValue = (opt) => (typeof opt === "string" ? opt : opt.value);
+const optionLabel = (opt) => (typeof opt === "string" ? opt : opt.label);
+
+const defaultProfile = {
+  category: "",
+  gender: "",
+  homeState: "",
+  mainRank: "",
+  qualifiedJeeAdv: "No",
+  advRank: "",
+};
+
+const defaultState = {
+  step: "info",
+  profile: defaultProfile,
+  choices: [],
+  locked: false,
+  trail: [], // [{round, provisional, mode}], built up as rounds are revealed
+  frozen: false,
+};
+
+function loadPersistedState() {
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return defaultState;
+    const parsed = JSON.parse(raw);
+    return { ...defaultState, ...parsed, profile: { ...defaultProfile, ...parsed.profile } };
+  } catch {
+    return defaultState;
+  }
+}
+
+const matchesProgramType = (programName, type) => {
+  const lower = (programName || "").toLowerCase();
+  if (type === "architecture") return lower.includes("architecture");
+  if (type === "planning") return lower.includes("planning");
+  if (type === "engineering") {
+    return !lower.includes("architecture") && !lower.includes("planning");
+  }
+  return true; // "all"
+};
+
+const formatRank = (rank) => (rank == null ? "—" : Number(rank).toLocaleString("en-IN"));
+const formatSalary = (value) =>
+  value == null ? "—" : `₹${Number(value).toLocaleString("en-IN")}`;
+
+const cardClass = "rounded-xl border border-[#eaded8] bg-white p-4 shadow-sm";
+const inputClass =
+  "w-full rounded-xl border border-[#d8c7c1] bg-[#fffdfa] px-3 py-2 outline-none transition focus:border-[#b52326] focus:ring-2 focus:ring-[#f4d5d6]";
+const primaryBtn =
+  "rounded-full bg-[#b52326] px-5 py-2 text-sm font-semibold text-white transition hover:bg-[#98191c] disabled:cursor-not-allowed disabled:opacity-40";
+const secondaryBtn =
+  "rounded-full border border-[#d8c7c1] px-5 py-2 text-sm font-semibold text-[#5b4a45] transition hover:bg-[#f8efec] disabled:cursor-not-allowed disabled:opacity-40";
+
+const MockAllotment = () => {
+  const [state, setState] = useState(defaultState);
+  const [hydrated, setHydrated] = useState(false);
+
+  const [rows, setRows] = useState(null);
+  const [collegesByName, setCollegesByName] = useState(null);
+  const [dataError, setDataError] = useState("");
+  const [dataLoading, setDataLoading] = useState(false);
+
+  const [search, setSearch] = useState("");
+  const [instituteFilter, setInstituteFilter] = useState("");
+  const [programType, setProgramType] = useState("all");
+
+  // Load any in-progress mock from localStorage once, on mount.
+  useEffect(() => {
+    setState(loadPersistedState());
+    setHydrated(true);
+  }, []);
+
+  // Persist after every change, once hydrated (so we don't overwrite a saved
+  // session with the defaults during the very first render).
+  useEffect(() => {
+    if (!hydrated) return;
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+  }, [state, hydrated]);
+
+  // Load the JoSAA round data + college enrichment once the student needs it.
+  useEffect(() => {
+    if (state.step === "info" || rows || dataLoading) return;
+    setDataLoading(true);
+    setDataError("");
+    Promise.all([loadAllRoundsData(), loadCollegesData()])
+      .then(([rowsData, colleges]) => {
+        setRows(rowsData);
+        setCollegesByName(colleges);
+      })
+      .catch((err) => setDataError(err.message || "Could not load JoSAA data."))
+      .finally(() => setDataLoading(false));
+  }, [state.step, rows, dataLoading]);
+
+  const seatIndex = useMemo(() => (rows ? buildSeatIndex(rows) : null), [rows]);
+
+  const catalog = useMemo(() => {
+    if (!rows || !collegesByName || !state.profile.category || !state.profile.gender) {
+      return [];
+    }
+    return buildCatalog(rows, state.profile, collegesByName);
+  }, [rows, collegesByName, state.profile]);
+
+  const instituteOptions = useMemo(
+    () => Array.from(new Set(catalog.map((c) => c.institute))).sort(),
+    [catalog]
+  );
+
+  const filteredCatalog = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    return catalog.filter((item) => {
+      if (instituteFilter && item.institute !== instituteFilter) return false;
+      if (!matchesProgramType(item.program, programType)) return false;
+      if (!q) return true;
+      return (
+        item.institute.toLowerCase().includes(q) || item.program.toLowerCase().includes(q)
+      );
+    });
+  }, [catalog, search, instituteFilter, programType]);
+
+  const chosenKeys = useMemo(
+    () => new Set(state.choices.map((c) => `${c.institute}|${c.program}`)),
+    [state.choices]
+  );
+
+  // Round 1 has no prior state, so it's computed once, automatically, as soon
+  // as the student locks in and the data is ready. Every later round is only
+  // computed when the student actually chooses float/slide (see onAdvance) —
+  // the whole point is that the choice made at each round changes what gets
+  // checked next, so it can't be precomputed upfront.
+  useEffect(() => {
+    if (!hydrated || state.step !== "simulate" || !state.locked) return;
+    if (state.trail.length > 0) return;
+    if (!seatIndex || !collegesByName || state.choices.length === 0) return;
+    const first = getRoundOneResult(state.choices, state.profile, seatIndex, collegesByName);
+    setState((s) => (s.trail.length > 0 ? s : { ...s, trail: [{ round: 1, provisional: first, mode: null }] }));
+  }, [hydrated, state.step, state.locked, state.trail.length, state.choices, state.profile, seatIndex, collegesByName]);
+
+  const current = state.trail.length > 0 ? state.trail[state.trail.length - 1] : null;
+  const isFinalRound = current ? current.round >= TOTAL_ROUNDS : false;
+  const finalRevealed = state.frozen || isFinalRound;
+
+  const missedOptions = useMemo(() => {
+    if (
+      !finalRevealed ||
+      !current?.provisional ||
+      !seatIndex ||
+      !collegesByName ||
+      catalog.length === 0
+    ) {
+      return [];
+    }
+    return findMissedBetterOptions(
+      catalog,
+      state.choices,
+      current.provisional.choice,
+      current.round,
+      seatIndex,
+      state.profile,
+      collegesByName
+    );
+  }, [finalRevealed, current, catalog, state.choices, state.profile, seatIndex, collegesByName]);
+
+  const setStep = (step) => setState((s) => ({ ...s, step }));
+  const setProfile = (patch) =>
+    setState((s) => ({ ...s, profile: { ...s.profile, ...patch } }));
+
+  const addChoice = (item) => {
+    setState((s) => {
+      const key = `${item.institute}|${item.program}`;
+      if (s.choices.some((c) => `${c.institute}|${c.program}` === key)) return s;
+      return { ...s, choices: [...s.choices, item] };
+    });
+  };
+  const removeChoice = (index) => {
+    setState((s) => ({ ...s, choices: s.choices.filter((_, i) => i !== index) }));
+  };
+  // Used by the Review step's drag-and-drop. `gapIndex` is a position BETWEEN
+  // items in the ORIGINAL (pre-drag) array — 0..choices.length, where
+  // choices.length means "after the last item". Removing fromIndex first
+  // shifts everything after it back by one, so a gap that sat after the
+  // dragged item needs that same shift applied before inserting, or a
+  // downward drag lands one slot short (and dropping past the last item
+  // would be indistinguishable from dropping just before it).
+  const reorderChoices = (fromIndex, gapIndex) => {
+    setState((s) => {
+      if (fromIndex < 0 || fromIndex >= s.choices.length) return s;
+      const next = [...s.choices];
+      const [moved] = next.splice(fromIndex, 1);
+      const insertAt = gapIndex > fromIndex ? gapIndex - 1 : gapIndex;
+      next.splice(insertAt, 0, moved);
+      return { ...s, choices: next };
+    });
+  };
+
+  // Adjacent swaps, expressed as gaps for reorderChoices — up: the gap just
+  // before the previous item; down: the gap just after the next item.
+  const moveChoiceUp = (index) => reorderChoices(index, Math.max(0, index - 1));
+  const moveChoiceDown = (index) => reorderChoices(index, index + 2);
+
+  // Manual "type a number to jump there" reordering. position1Based is what
+  // the student typed (1 = top of the list).
+  const moveChoiceToPosition = (fromIndex, position1Based) => {
+    setState((s) => {
+      const desiredIndex = Math.max(0, Math.min(position1Based - 1, s.choices.length - 1));
+      if (desiredIndex === fromIndex) return s;
+      const gapIndex = desiredIndex >= fromIndex ? desiredIndex + 1 : desiredIndex;
+      const next = [...s.choices];
+      const [moved] = next.splice(fromIndex, 1);
+      const insertAt = gapIndex > fromIndex ? gapIndex - 1 : gapIndex;
+      next.splice(insertAt, 0, moved);
+      return { ...s, choices: next };
+    });
+  };
+
+  const lockChoices = () =>
+    setState((s) => ({ ...s, locked: true, trail: [], frozen: false, step: "simulate" }));
+  const unlock = () =>
+    setState((s) => ({ ...s, locked: false, trail: [], frozen: false, step: "choices" }));
+
+  const freeze = () => setState((s) => ({ ...s, frozen: true }));
+
+  // mode: "float" (search the whole list) or "slide" (same institute only).
+  const advance = (mode) => {
+    setState((s) => {
+      const last = s.trail[s.trail.length - 1];
+      if (!last || last.round >= TOTAL_ROUNDS) return s;
+      const next = advanceRound(
+        s.choices,
+        s.profile,
+        seatIndex,
+        collegesByName,
+        last.round + 1,
+        last.provisional,
+        mode
+      );
+      return { ...s, trail: [...s.trail, next] };
+    });
+  };
+
+  const restart = () => {
+    window.localStorage.removeItem(STORAGE_KEY);
+    setState(defaultState);
+    setSearch("");
+    setInstituteFilter("");
+    setProgramType("all");
+  };
+
+  const profileValid =
+    state.profile.category &&
+    state.profile.gender &&
+    state.profile.homeState &&
+    Number(state.profile.mainRank) > 0 &&
+    (state.profile.qualifiedJeeAdv !== "Yes" || Number(state.profile.advRank) > 0);
+
+  if (!hydrated) return null;
+
+  return (
+    <div className="mx-auto w-full max-w-7xl px-4 py-4 md:px-8">
+      <h1 className="text-2xl font-bold text-[#3a2c28] md:text-3xl">
+        JoSAA Mock Allotment
+      </h1>
+      <p className="mt-1 text-sm text-[#7a655f]">
+        Practice choice-filling, locking, and the freeze/float rounds using real
+        JoSAA 2025 cutoff data — a training tool, not the real counselling.
+      </p>
+
+      <StepBar current={state.step} locked={state.locked} onSelect={setStep} />
+
+      {state.step === "info" && (
+        <InfoStep
+          profile={state.profile}
+          setProfile={setProfile}
+          onNext={() => setStep("choices")}
+          valid={profileValid}
+        />
+      )}
+
+      {state.step === "choices" && (
+        <ChoicesStep
+          loading={dataLoading}
+          error={dataError}
+          catalog={filteredCatalog}
+          totalCatalogSize={catalog.length}
+          chosenKeys={chosenKeys}
+          choices={state.choices}
+          search={search}
+          setSearch={setSearch}
+          instituteFilter={instituteFilter}
+          setInstituteFilter={setInstituteFilter}
+          instituteOptions={instituteOptions}
+          programType={programType}
+          setProgramType={setProgramType}
+          onAdd={addChoice}
+          onRemove={removeChoice}
+          onReorder={reorderChoices}
+          onMoveUp={moveChoiceUp}
+          onMoveDown={moveChoiceDown}
+          onMoveToPosition={moveChoiceToPosition}
+          onBack={() => setStep("info")}
+          onNext={() => setStep("review")}
+        />
+      )}
+
+      {state.step === "review" && (
+        <ReviewStep
+          profile={state.profile}
+          choices={state.choices}
+          locked={state.locked}
+          onBack={() => setStep("choices")}
+          onLock={lockChoices}
+          onUnlock={unlock}
+          onProceed={() => setStep("simulate")}
+          onReorder={reorderChoices}
+          onMoveUp={moveChoiceUp}
+          onMoveDown={moveChoiceDown}
+          onMoveToPosition={moveChoiceToPosition}
+          onRemove={removeChoice}
+        />
+      )}
+
+      {state.step === "simulate" && (
+        <SimulateStep
+          locked={state.locked}
+          choices={state.choices}
+          trail={state.trail}
+          current={current}
+          finalRevealed={finalRevealed}
+          isFinalRound={isFinalRound}
+          missedOptions={missedOptions}
+          collegesByName={collegesByName}
+          onFreeze={freeze}
+          onAdvance={advance}
+          onUnlock={unlock}
+          onRestart={restart}
+        />
+      )}
+    </div>
+  );
+};
+
+const StepBar = ({ current, locked, onSelect }) => (
+  <div className="mt-6 flex flex-wrap gap-2">
+    {STEPS.map((step) => {
+      const isDisabled = step === "simulate" && !locked;
+      return (
+        <button
+          key={step}
+          type="button"
+          disabled={isDisabled}
+          onClick={() => onSelect(step)}
+          className={`rounded-full px-3 py-1.5 text-xs font-semibold transition ${
+            current === step
+              ? "bg-[#b52326] text-white"
+              : "border border-[#d8c7c1] text-[#5b4a45] hover:bg-[#f8efec]"
+          } disabled:cursor-not-allowed disabled:opacity-40`}
+        >
+          {STEP_LABELS[step]}
+        </button>
+      );
+    })}
+  </div>
+);
+
+const Field = ({ label, children }) => (
+  <label className="block">
+    <span className="mb-1 block text-sm font-semibold text-[#5b4a45]">{label}</span>
+    {children}
+  </label>
+);
+
+const InfoStep = ({ profile, setProfile, onNext, valid }) => (
+  <div className={`${cardClass} mt-6`}>
+    <div className="grid gap-4 md:grid-cols-2">
+      <Field label={categoryField.label}>
+        <select
+          className={inputClass}
+          value={profile.category}
+          onChange={(e) => setProfile({ category: e.target.value })}
+        >
+          <option value="">Select…</option>
+          {categoryField.options.map((opt) => (
+            <option key={optionValue(opt)} value={optionValue(opt)}>
+              {optionLabel(opt)}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field label={genderField.label}>
+        <select
+          className={inputClass}
+          value={profile.gender}
+          onChange={(e) => setProfile({ gender: e.target.value })}
+        >
+          <option value="">Select…</option>
+          {genderField.options.map((opt) => (
+            <option key={optionValue(opt)} value={optionValue(opt)}>
+              {optionLabel(opt)}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field label="Select Your Home State">
+        <select
+          className={inputClass}
+          value={profile.homeState}
+          onChange={(e) => setProfile({ homeState: e.target.value })}
+        >
+          <option value="">Select…</option>
+          {statesList.map((s) => (
+            <option key={s} value={s}>
+              {s}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      <Field label="Enter JEE Main Category Rank">
+        <input
+          type="number"
+          min="1"
+          className={inputClass}
+          value={profile.mainRank}
+          onChange={(e) => setProfile({ mainRank: e.target.value })}
+          placeholder="e.g., 15000"
+        />
+      </Field>
+
+      <Field label={qualifiedField.label}>
+        <select
+          className={inputClass}
+          value={profile.qualifiedJeeAdv}
+          onChange={(e) => setProfile({ qualifiedJeeAdv: e.target.value })}
+        >
+          {qualifiedField.options.map((opt) => (
+            <option key={optionValue(opt)} value={optionValue(opt)}>
+              {optionLabel(opt)}
+            </option>
+          ))}
+        </select>
+      </Field>
+
+      {profile.qualifiedJeeAdv === "Yes" && (
+        <Field label="Enter JEE Advanced Category Rank">
+          <input
+            type="number"
+            min="1"
+            className={inputClass}
+            value={profile.advRank}
+            onChange={(e) => setProfile({ advRank: e.target.value })}
+            placeholder="e.g., 4000"
+          />
+        </Field>
+      )}
+    </div>
+
+    <p className="mt-3 text-xs text-[#7a655f]">
+      Program type isn&apos;t asked here — you&apos;ll filter by Engineering /
+      Architecture / Planning while browsing choices, same as real JoSAA lets
+      you mix them in one list.
+    </p>
+
+    <div className="mt-5 flex justify-end">
+      <button type="button" className={primaryBtn} disabled={!valid} onClick={onNext}>
+        Continue to Choice Filling →
+      </button>
+    </div>
+  </div>
+);
+
+const CatalogRow = ({ item, added, onAdd }) => (
+  <div className="flex items-center justify-between gap-3 border-b border-[#f0e6e1] px-3 py-2 last:border-b-0">
+    <div className="min-w-0">
+      <p className="text-sm font-semibold text-[#3a2c28]">{item.institute}</p>
+      <p className="text-xs text-[#7a655f]">{item.program}</p>
+      {/* Deliberately no cutoff/rank shown here — this is a practice mock, not
+          the predictor. Seeing which seats are "easy" before you build your
+          list defeats the point: real JoSAA doesn't tell you either. */}
+      <p className="mt-0.5 text-[11px] text-[#9a8a84]">Quota: {item.quota}</p>
+    </div>
+    <button
+      type="button"
+      disabled={added}
+      onClick={() => onAdd(item)}
+      className={`shrink-0 rounded-full px-3 py-1 text-xs font-semibold transition ${
+        added
+          ? "cursor-not-allowed bg-[#f0e6e1] text-[#9a8a84]"
+          : "bg-[#b52326] text-white hover:bg-[#98191c]"
+      }`}
+    >
+      {added ? "Added ✓" : "+ Add"}
+    </button>
+  </div>
+);
+
+// Reorder controls shared by the Choice Filling and Review & Manage steps —
+// drag handle, ↑/↓ buttons, and a type-a-number-to-jump box, all driving the
+// same set of handlers. Used any time a choice list needs to be editable.
+const ReorderableChoiceList = ({ choices, onReorder, onMoveUp, onMoveDown, onMoveToPosition, onRemove }) => {
+  // Pointer Events (not the native HTML5 drag API) so the same handlers drive
+  // mouse, touch, and pen — the native drag API doesn't fire on touch at all,
+  // which would leave mobile students with no way to reorder.
+  const [dragIndex, setDragIndex] = useState(null);
+  // A GAP position in the pre-drag array, not an item index: 0..choices.length,
+  // where choices.length means "after the last item". onReorder expects this
+  // exact shape — see reorderChoices' comment for why a plain index isn't enough.
+  const [overGap, setOverGap] = useState(null);
+  // Where the pointer currently is, so a floating label can follow it — the
+  // browser's native drag API draws its own ghost image automatically;
+  // Pointer Events don't, so without this the item being dragged is
+  // invisible the whole time it's moving (only the dimmed original row and
+  // the drop-target highlight are visible otherwise).
+  const [pointerPos, setPointerPos] = useState(null);
+  const itemRefs = useRef([]);
+  // Manual "type a number, jump there" input state, per row (keyed by pair)
+  // so mid-typing values aren't clobbered by re-renders from other rows.
+  const [positionDrafts, setPositionDrafts] = useState({});
+
+  const findGapAtY = (clientY) => {
+    for (let i = 0; i < itemRefs.current.length; i += 1) {
+      const rect = itemRefs.current[i]?.getBoundingClientRect();
+      if (rect && clientY < rect.top + rect.height / 2) return i;
+    }
+    return choices.length;
+  };
+
+  const handlePointerDown = (index) => (e) => {
+    e.currentTarget.setPointerCapture(e.pointerId); // routes later move/up here even off-element
+    setDragIndex(index);
+    setOverGap(index);
+    setPointerPos({ x: e.clientX, y: e.clientY });
+  };
+  const handlePointerMove = (e) => {
+    if (dragIndex === null) return;
+    setPointerPos({ x: e.clientX, y: e.clientY });
+    const target = findGapAtY(e.clientY);
+    if (target !== overGap) setOverGap(target);
+  };
+  const endDrag = () => {
+    // A gap equal to fromIndex or fromIndex+1 both mean "drop back where it
+    // started" (nothing before/after it actually moves), so only reorder
+    // outside that no-op range.
+    if (dragIndex !== null && overGap !== null && overGap !== dragIndex && overGap !== dragIndex + 1) {
+      onReorder(dragIndex, overGap);
+    }
+    setDragIndex(null);
+    setOverGap(null);
+    setPointerPos(null);
+  };
+
+  const commitPosition = (index, key) => {
+    const raw = positionDrafts[key];
+    setPositionDrafts((d) => {
+      const next = { ...d };
+      delete next[key];
+      return next;
+    });
+    if (raw === undefined || raw === "") return;
+    const parsed = Number(raw);
+    if (Number.isFinite(parsed)) onMoveToPosition(index, parsed);
+  };
+
+  // Approximate which row to highlight as the drop target — just the
+  // nearest row to the gap, not a true "insert here" line between rows.
+  const highlightIndex = overGap === null ? null : Math.min(overGap, choices.length - 1);
+
+  return (
+    <>
+      <ol className="mt-3 space-y-2">
+        {choices.map((item, index) => {
+          const key = `${item.institute}|${item.program}`;
+          return (
+            <li
+              key={key}
+              ref={(el) => {
+                itemRefs.current[index] = el;
+              }}
+              className={`flex items-center gap-2 rounded-lg border px-3 py-2 text-sm transition ${
+                highlightIndex === index ? "border-[#b52326] bg-[#fdf3f1]" : "border-[#f0e6e1]"
+              } ${dragIndex === index ? "opacity-50" : ""}`}
+            >
+              <span
+                onPointerDown={handlePointerDown(index)}
+                onPointerMove={handlePointerMove}
+                onPointerUp={endDrag}
+                onPointerCancel={endDrag}
+                style={{ touchAction: "none" }}
+                className="shrink-0 cursor-grab touch-none active:cursor-grabbing"
+                aria-label="Drag to reorder"
+              >
+                <GripVertical size={16} className="text-[#c9b8b2]" />
+              </span>
+              <input
+                type="number"
+                min={1}
+                max={choices.length}
+                value={positionDrafts[key] ?? index + 1}
+                onChange={(e) => setPositionDrafts((d) => ({ ...d, [key]: e.target.value }))}
+                onBlur={() => commitPosition(index, key)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter") e.currentTarget.blur();
+                }}
+                className="w-11 shrink-0 rounded border border-[#d8c7c1] bg-[#fffdfa] px-1 py-0.5 text-center text-xs font-bold text-[#b52326] outline-none focus:border-[#b52326]"
+                aria-label="Move to position"
+              />
+              <div className="min-w-0 flex-1">
+                <p className="text-sm font-semibold text-[#3a2c28]">{item.institute}</p>
+                <p className="text-xs text-[#7a655f]">{item.program}</p>
+              </div>
+              <div className="flex shrink-0 gap-1">
+                <button
+                  type="button"
+                  disabled={index === 0}
+                  onClick={() => onMoveUp(index)}
+                  className="rounded-full border border-[#d8c7c1] px-2 py-1 text-xs disabled:opacity-30"
+                  aria-label="Move up"
+                >
+                  ↑
+                </button>
+                <button
+                  type="button"
+                  disabled={index === choices.length - 1}
+                  onClick={() => onMoveDown(index)}
+                  className="rounded-full border border-[#d8c7c1] px-2 py-1 text-xs disabled:opacity-30"
+                  aria-label="Move down"
+                >
+                  ↓
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onRemove(index)}
+                  className="rounded-full border border-[#d8c7c1] px-2 py-1 text-xs text-[#b52326]"
+                  aria-label="Remove"
+                >
+                  ×
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+
+      {dragIndex !== null && pointerPos && (
+        <div
+          style={{ position: "fixed", left: pointerPos.x + 16, top: pointerPos.y + 16, zIndex: 9999 }}
+          className="pointer-events-none max-w-[240px] rounded-lg border-2 border-[#b52326] bg-white px-3 py-2 text-xs font-semibold text-[#3a2c28] shadow-lg"
+        >
+          #{dragIndex + 1}. {choices[dragIndex]?.institute}
+        </div>
+      )}
+    </>
+  );
+};
+
+const ChoicesStep = ({
+  loading,
+  error,
+  catalog,
+  totalCatalogSize,
+  chosenKeys,
+  choices,
+  search,
+  setSearch,
+  instituteFilter,
+  setInstituteFilter,
+  instituteOptions,
+  programType,
+  setProgramType,
+  onAdd,
+  onRemove,
+  onReorder,
+  onMoveUp,
+  onMoveDown,
+  onMoveToPosition,
+  onBack,
+  onNext,
+}) => (
+  <div className="mt-6 grid gap-6 md:grid-cols-2">
+    <div className={cardClass}>
+      <h2 className="text-sm font-bold text-[#3a2c28]">
+        Browse choices {totalCatalogSize ? `(${totalCatalogSize} eligible for you)` : ""}
+      </h2>
+
+      <div className="mt-3 grid gap-2 sm:grid-cols-2">
+        <input
+          className={inputClass}
+          placeholder="Search institute or program…"
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+        />
+        <select
+          className={inputClass}
+          value={instituteFilter}
+          onChange={(e) => setInstituteFilter(e.target.value)}
+        >
+          <option value="">All institutes</option>
+          {instituteOptions.map((name) => (
+            <option key={name} value={name}>
+              {name}
+            </option>
+          ))}
+        </select>
+        <select
+          className={`${inputClass} sm:col-span-2`}
+          value={programType}
+          onChange={(e) => setProgramType(e.target.value)}
+        >
+          <option value="all">All program types</option>
+          <option value="engineering">Engineering</option>
+          <option value="architecture">Architecture</option>
+          <option value="planning">Planning</option>
+        </select>
+      </div>
+
+      <div className="mt-3 max-h-96 overflow-y-auto rounded-lg border border-[#f0e6e1]">
+        {loading && <p className="p-4 text-sm text-[#7a655f]">Loading JoSAA data…</p>}
+        {error && <p className="p-4 text-sm text-[#b52326]">{error}</p>}
+        {!loading && !error && catalog.length === 0 && (
+          <p className="p-4 text-sm text-[#7a655f]">
+            No matching choices. Try clearing filters.
+          </p>
+        )}
+        {!loading &&
+          !error &&
+          catalog.map((item) => (
+            <CatalogRow
+              key={`${item.institute}|${item.program}`}
+              item={item}
+              added={chosenKeys.has(`${item.institute}|${item.program}`)}
+              onAdd={onAdd}
+            />
+          ))}
+      </div>
+    </div>
+
+    <div className={cardClass}>
+      <h2 className="text-sm font-bold text-[#3a2c28]">
+        Your preference order ({choices.length})
+      </h2>
+      {choices.length === 0 ? (
+        <p className="mt-3 text-sm text-[#7a655f]">
+          Add choices from the left — drag, use ↑/↓, or type a position number to reorder them as
+          you go.
+        </p>
+      ) : (
+        <ReorderableChoiceList
+          choices={choices}
+          onReorder={onReorder}
+          onMoveUp={onMoveUp}
+          onMoveDown={onMoveDown}
+          onMoveToPosition={onMoveToPosition}
+          onRemove={onRemove}
+        />
+      )}
+
+      <div className="mt-5 flex justify-between">
+        <button type="button" className={secondaryBtn} onClick={onBack}>
+          ← Edit student info
+        </button>
+        <button
+          type="button"
+          className={primaryBtn}
+          disabled={choices.length === 0}
+          onClick={onNext}
+        >
+          Continue to Review →
+        </button>
+      </div>
+    </div>
+  </div>
+);
+
+const ReviewStep = ({
+  profile,
+  choices,
+  locked,
+  onBack,
+  onLock,
+  onUnlock,
+  onProceed,
+  onReorder,
+  onMoveUp,
+  onMoveDown,
+  onMoveToPosition,
+  onRemove,
+}) => (
+  <div className={`${cardClass} mt-6`}>
+    <h2 className="text-sm font-bold text-[#3a2c28]">Your profile</h2>
+    <div className="mt-2 flex flex-wrap gap-2 text-xs text-[#5b4a45]">
+      {[
+        optionLabel(categoryField.options.find((o) => optionValue(o) === profile.category)) ||
+          profile.category,
+        profile.gender,
+        profile.homeState,
+        `JEE Main rank: ${profile.mainRank}`,
+        profile.qualifiedJeeAdv === "Yes" ? `JEE Advanced rank: ${profile.advRank}` : null,
+      ]
+        .filter(Boolean)
+        .map((chip) => (
+          <span key={chip} className="rounded-full bg-[#f8efec] px-3 py-1">
+            {chip}
+          </span>
+        ))}
+    </div>
+
+    <h2 className="mt-5 text-sm font-bold text-[#3a2c28]">
+      {locked ? "Locked" : "Review &"} preference order ({choices.length})
+    </h2>
+
+    {!locked ? (
+      <>
+        <p className="mt-1 text-xs text-[#7a655f]">
+          Drag the grip, use the ↑/↓ buttons, or type a position number to reorder — #1 is your
+          top preference, same as JoSAA&apos;s own choice list.
+        </p>
+        <ReorderableChoiceList
+          choices={choices}
+          onReorder={onReorder}
+          onMoveUp={onMoveUp}
+          onMoveDown={onMoveDown}
+          onMoveToPosition={onMoveToPosition}
+          onRemove={onRemove}
+        />
+      </>
+    ) : (
+      <ol className="mt-2 space-y-1">
+        {choices.map((item, index) => (
+          <li
+            key={`${item.institute}|${item.program}`}
+            className="rounded-lg border border-[#f0e6e1] px-3 py-2 text-sm"
+          >
+            <span className="mr-2 font-bold text-[#b52326]">{index + 1}.</span>
+            {item.institute} — <span className="text-[#7a655f]">{item.program}</span>
+          </li>
+        ))}
+      </ol>
+    )}
+
+    <div className="mt-5 flex flex-wrap justify-between gap-2">
+      {!locked ? (
+        <>
+          <button type="button" className={secondaryBtn} onClick={onBack}>
+            ← Back to add more choices
+          </button>
+          <button
+            type="button"
+            className={primaryBtn}
+            disabled={choices.length === 0}
+            onClick={onLock}
+          >
+            🔒 Lock My Choices
+          </button>
+        </>
+      ) : (
+        <>
+          <button type="button" className={secondaryBtn} onClick={onUnlock}>
+            Unlock & edit choices
+          </button>
+          <button type="button" className={primaryBtn} onClick={onProceed}>
+            Proceed to Simulation →
+          </button>
+        </>
+      )}
+    </div>
+  </div>
+);
+
+const RoundCard = ({ current, choicesCount }) => {
+  if (!current) return null;
+  if (!current.provisional) {
+    return (
+      <div className={`${cardClass} border-dashed`}>
+        <p className="text-sm text-[#7a655f]">
+          No seat in your list is reachable in Round {current.round} yet.
+        </p>
+      </div>
+    );
+  }
+  const { choice, index, opening, closing, quota, gender } = current.provisional;
+  return (
+    <div className={cardClass}>
+      <p className="text-xs font-semibold uppercase tracking-wide text-[#b52326]">
+        Round {current.round} of {TOTAL_ROUNDS} — provisional seat
+      </p>
+      <p className="mt-1 text-lg font-bold text-[#3a2c28]">{choice.institute}</p>
+      <p className="text-sm text-[#5b4a45]">{choice.program}</p>
+      <p className="mt-2 text-xs text-[#7a655f]">
+        Your preference #{index + 1} of {choicesCount} · Quota {quota} · Pool {gender} · Opening{" "}
+        {formatRank(opening)} / Closing {formatRank(closing)}
+      </p>
+    </div>
+  );
+};
+
+const MISSED_OPTIONS_TABS = [
+  {
+    key: "closingRank",
+    label: "By Closing Rank",
+    note: "Most reliable — the actual seat-level cutoff, with full coverage. JEE Main and JEE Advanced can't be ranked against each other on this number though (different candidate pools), so they're grouped separately below.",
+  },
+  {
+    key: "nirf",
+    label: "By NIRF Ranking",
+    note: "College-level rank (not branch-level), and only about half of institutes are NIRF-ranked at all. Comparable across JEE Main and JEE Advanced institutes alike.",
+  },
+  {
+    key: "salary",
+    label: "By Median Salary",
+    note: "This median is across ALL branches of the college, not this specific branch — the least reliable of the three. Closing rank is the most accurate comparison.",
+  },
+];
+
+const MISSED_OPTIONS_DISPLAY_LIMIT = 8;
+
+const missedOptionRow = (opt) => (
+  <li
+    key={`${opt.institute}|${opt.program}`}
+    className="rounded-lg border border-[#f0e6e1] px-3 py-2 text-sm"
+  >
+    <p className="font-semibold text-[#3a2c28]">{opt.institute}</p>
+    <p className="text-xs text-[#7a655f]">{opt.program}</p>
+    <p className="mt-1 text-[11px] text-[#9a8a84]">
+      Closing rank: {formatRank(opt.closingRank)} · NIRF: {opt.nirfRank ?? "not ranked"} · Salary:{" "}
+      {formatSalary(opt.medianSalary)}
+      {opt.listPosition != null && (
+        <>
+          {" "}
+          ·{" "}
+          <span className="font-semibold text-[#b52326]">
+            Was your choice #{opt.listPosition}
+          </span>
+        </>
+      )}
+    </p>
+  </li>
+);
+
+const MissedOptionsPanel = ({ missedOptions, round }) => {
+  const [tab, setTab] = useState("closingRank");
+  const activeTab = MISSED_OPTIONS_TABS.find((t) => t.key === tab);
+
+  return (
+    <div className={cardClass}>
+      <h2 className="text-sm font-bold text-[#3a2c28]">You may have gotten a better option</h2>
+      <p className="mt-1 text-xs text-[#7a655f]">
+        These were also reachable in Round {round} — some weren&apos;t in your list at all,
+        others you&apos;d ranked lower than what you got (flagged below).
+      </p>
+
+      <div className="mt-3 flex flex-wrap gap-1">
+        {MISSED_OPTIONS_TABS.map((t) => (
+          <button
+            key={t.key}
+            type="button"
+            onClick={() => setTab(t.key)}
+            className={`rounded-full px-3 py-1 text-xs font-semibold transition ${
+              tab === t.key
+                ? "bg-[#b52326] text-white"
+                : "border border-[#d8c7c1] text-[#5b4a45] hover:bg-[#f8efec]"
+            }`}
+          >
+            {t.label}
+          </button>
+        ))}
+      </div>
+      <p className="mt-2 text-[11px] text-[#9a8a84]">{activeTab.note}</p>
+
+      {tab === "closingRank" && (
+        <ClosingRankGroups missedOptions={missedOptions} />
+      )}
+      {tab !== "closingRank" && (
+        <RankedList
+          items={missedOptions}
+          metricKey={tab === "nirf" ? "nirfRank" : "medianSalary"}
+          direction={tab === "nirf" ? "asc" : "desc"}
+          emptyMessage={`None of the missed options have ${
+            tab === "nirf" ? "an NIRF rank" : "a salary figure"
+          } on record.`}
+        />
+      )}
+    </div>
+  );
+};
+
+// JEE Main and JEE Advanced closing ranks are different rank spaces (see
+// examSpaceFor in utils/josaaSimulator.js) — shown as two groups, never
+// merged into one sorted list.
+const ClosingRankGroups = ({ missedOptions }) => {
+  const advanced = missedOptions
+    .filter((o) => o.exam === "JEE Advanced")
+    .sort((a, b) => a.closingRank - b.closingRank)
+    .slice(0, MISSED_OPTIONS_DISPLAY_LIMIT);
+  const main = missedOptions
+    .filter((o) => o.exam === "JEE Main")
+    .sort((a, b) => a.closingRank - b.closingRank)
+    .slice(0, MISSED_OPTIONS_DISPLAY_LIMIT);
+
+  if (advanced.length === 0 && main.length === 0) {
+    return <p className="mt-3 text-sm text-[#7a655f]">No missed options found.</p>;
+  }
+
+  return (
+    <div className="mt-3 space-y-4">
+      {advanced.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-[#5b4a45]">JEE Advanced institutes (IITs)</p>
+          <ul className="mt-2 space-y-2">{advanced.map(missedOptionRow)}</ul>
+        </div>
+      )}
+      {main.length > 0 && (
+        <div>
+          <p className="text-xs font-semibold text-[#5b4a45]">
+            JEE Main institutes (NITs / IIITs / GFTIs)
+          </p>
+          <ul className="mt-2 space-y-2">{main.map(missedOptionRow)}</ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+const RankedList = ({ items, metricKey, direction, emptyMessage }) => {
+  const sorted = items
+    .filter((o) => o[metricKey] != null)
+    .sort((a, b) => (direction === "asc" ? a[metricKey] - b[metricKey] : b[metricKey] - a[metricKey]))
+    .slice(0, MISSED_OPTIONS_DISPLAY_LIMIT);
+
+  if (sorted.length === 0) {
+    return <p className="mt-3 text-sm text-[#7a655f]">{emptyMessage}</p>;
+  }
+  return <ul className="mt-3 space-y-2">{sorted.map(missedOptionRow)}</ul>;
+};
+
+const SimulateStep = ({
+  locked,
+  choices,
+  trail,
+  current,
+  finalRevealed,
+  isFinalRound,
+  missedOptions,
+  collegesByName,
+  onFreeze,
+  onAdvance,
+  onUnlock,
+  onRestart,
+}) => {
+  if (!locked) {
+    return (
+      <div className={`${cardClass} mt-6`}>
+        <p className="text-sm text-[#7a655f]">Lock your choices first to run the simulation.</p>
+      </div>
+    );
+  }
+  if (!current) {
+    return (
+      <div className={`${cardClass} mt-6`}>
+        <p className="text-sm text-[#7a655f]">Preparing your simulation…</p>
+      </div>
+    );
+  }
+
+  const finalChoice = current.provisional;
+  const college = finalChoice ? collegesByName?.get(finalChoice.choice.institute) : null;
+  const indicativeRank = finalChoice
+    ? findIndicativeRank(college, finalChoice.choice.program)
+    : null;
+  const canSlide = Boolean(finalChoice);
+
+  return (
+    <div className="mt-6 space-y-6">
+      <RoundCard current={current} choicesCount={choices.length} />
+
+      <div className="flex flex-wrap gap-2">
+        {!finalRevealed && (
+          <>
+            <button type="button" className={primaryBtn} onClick={onFreeze}>
+              ❄️ Freeze this seat
+            </button>
+            <button type="button" className={secondaryBtn} onClick={() => onAdvance("float")}>
+              🔄 Float to Round {current.round + 1}
+            </button>
+            <button
+              type="button"
+              disabled={!canSlide}
+              title={
+                canSlide
+                  ? `Only look for a better branch at ${finalChoice.choice.institute}`
+                  : "You don't hold a seat yet, so there's nothing to slide within"
+              }
+              className={secondaryBtn}
+              onClick={() => onAdvance("slide")}
+            >
+              ↕️ Slide to Round {current.round + 1}
+            </button>
+          </>
+        )}
+        {finalRevealed && (
+          <p className="text-sm font-semibold text-[#3a2c28]">
+            {isFinalRound
+              ? "This was the final round — this is your result."
+              : "Frozen — this is your result."}
+          </p>
+        )}
+      </div>
+
+      {!finalRevealed && (
+        <p className="text-[11px] text-[#9a8a84]">
+          <strong>Float</strong> checks your whole list for anything better — could be a
+          different institute. <strong>Slide</strong> only checks other branches at{" "}
+          {canSlide ? finalChoice.choice.institute : "your current institute"} — you keep the
+          college, only the branch can improve.
+        </p>
+      )}
+
+      {/* Round-by-round trail so far */}
+      <div className="flex flex-wrap gap-1">
+        {trail.map((r) => (
+          <span
+            key={r.round}
+            className="rounded-full border border-[#d8c7c1] px-2 py-1 text-[11px] text-[#5b4a45]"
+          >
+            R{r.round}
+            {r.mode ? ` (${r.mode})` : ""}:{" "}
+            {r.provisional ? r.provisional.choice.institute.split(",")[0] : "no seat"}
+          </span>
+        ))}
+      </div>
+
+      {finalRevealed && finalChoice && (
+        <div className={cardClass}>
+          <h2 className="text-sm font-bold text-[#3a2c28]">Your simulated allotment</h2>
+          <p className="mt-2 text-base font-bold text-[#3a2c28]">
+            {finalChoice.choice.institute}
+          </p>
+          <p className="text-sm text-[#5b4a45]">{finalChoice.choice.program}</p>
+          <div className="mt-3 grid gap-2 text-xs text-[#5b4a45] sm:grid-cols-3">
+            <span className="rounded-full bg-[#f8efec] px-3 py-1">
+              NIRF Engg rank: {college?.nirf?.engineering_rank ?? "not ranked"}
+            </span>
+            <span className="rounded-full bg-[#f8efec] px-3 py-1">
+              Branch indicative closing rank: {formatRank(indicativeRank)}
+            </span>
+            <span className="rounded-full bg-[#f8efec] px-3 py-1">
+              Median salary (college-level): {formatSalary(college?.placement?.median_salary)}
+            </span>
+          </div>
+        </div>
+      )}
+
+      {finalRevealed && finalChoice && missedOptions.length > 0 && (
+        <MissedOptionsPanel missedOptions={missedOptions} round={current.round} />
+      )}
+
+      {finalRevealed && !finalChoice && (
+        <div className={cardClass}>
+          <p className="text-sm text-[#7a655f]">
+            Based on this rank and this list, no seat was reachable across any round. Go back
+            and add more (or less competitive) choices, or double check your rank.
+          </p>
+        </div>
+      )}
+
+      <p className="text-[11px] text-[#9a8a84]">
+        Based on JoSAA 2025 cutoffs across all 6 rounds. This mock does not simulate other
+        candidates&apos; choices or real-time seat withdrawal — it checks, each round, whether
+        your listed seats&apos; actual closing rank that round would have covered your rank.
+        NIRF rank and salary are per-college, not per-branch.
+      </p>
+
+      <div className="flex flex-wrap gap-2">
+        <button type="button" className={secondaryBtn} onClick={onUnlock}>
+          Unlock & edit choices
+        </button>
+        <button type="button" className={secondaryBtn} onClick={onRestart}>
+          ↺ Restart mock allotment
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default MockAllotment;

--- a/components/navbar.js
+++ b/components/navbar.js
@@ -53,6 +53,16 @@ const Navbar = ({ item1, item2 }) => {
             >
               {item2}
             </Link>
+            <Link
+              href="/mock-allotment"
+              className={`rounded-full px-3 py-1.5 text-sm font-semibold transition ${
+                pathname === "/mock-allotment"
+                  ? "bg-white/20"
+                  : "hover:bg-white/10 cursor-pointer"
+              }`}
+            >
+              Mock Allotment
+            </Link>
           </div>
           <Link
             href="https://cv-generator.avantifellows.org/"

--- a/examConfig.js
+++ b/examConfig.js
@@ -78,7 +78,10 @@ const josaaSpecialQuotaByHomeState = {
   Ladakh: "LA",
 };
 
-const matchesJosaaQuota = (item, homeState) => {
+// Exported so the mock-allotment simulator (utils/josaaSimulator.js) can reuse
+// the exact same AI/HS/OS/JK/GO/LA matching the live predictor uses, instead of
+// a second copy of this logic that could quietly drift out of sync.
+export const matchesJosaaQuota = (item, homeState) => {
   if (item.Quota === "AI") {
     return true;
   }

--- a/pages/mock-allotment.js
+++ b/pages/mock-allotment.js
@@ -1,0 +1,21 @@
+import Head from "next/head";
+import dynamic from "next/dynamic";
+
+// Client-only: reads/writes localStorage and fetches the JoSAA round data,
+// same reasoning as the Dropdown component in pages/index.js.
+const MockAllotment = dynamic(() => import("../components/MockAllotment"), {
+  ssr: false,
+});
+
+const MockAllotmentPage = () => {
+  return (
+    <>
+      <Head>
+        <title>JoSAA Mock Allotment</title>
+      </Head>
+      <MockAllotment />
+    </>
+  );
+};
+
+export default MockAllotmentPage;

--- a/utils/josaaSimulator.js
+++ b/utils/josaaSimulator.js
@@ -1,0 +1,394 @@
+/**
+ * JoSAA mock-allotment simulator.
+ *
+ * Data sources (see docs/SIMULATION_DATA.md for the full write-up):
+ *  - public/data/JEE/josaa_2025_all_rounds.json — every seat x all 6 rounds,
+ *    integer-coded (lookup arrays + index rows) to keep the file small.
+ *  - public/data/colleges/colleges.json — one row per institute, used for
+ *    (a) which rank space an institute uses (JEE Main vs JEE Advanced),
+ *    (b) which quotas it actually offers, and (c) the NIRF/salary critique.
+ *
+ * This module is pure data/logic (no React) so it can be unit-tested and
+ * reused outside pages/mock-allotment.js.
+ */
+
+import { matchesJosaaQuota } from "../examConfig";
+
+const ALL_ROUNDS_URL = "/data/JEE/josaa_2025_all_rounds.json";
+const COLLEGES_URL = "/data/colleges/colleges.json";
+const TOTAL_ROUNDS = 6;
+
+// category value (as used by examConfig.js's josaaConfig) -> Seat Type label
+// used in the JoSAA data files.
+export const CATEGORY_TO_SEAT_TYPE = {
+  open: "OPEN",
+  open_pwd: "OPEN (PwD)",
+  obc_ncl: "OBC-NCL",
+  obc_ncl_pwd: "OBC-NCL (PwD)",
+  sc: "SC",
+  sc_pwd: "SC (PwD)",
+  st: "ST",
+  st_pwd: "ST (PwD)",
+  ews: "EWS",
+  ews_pwd: "EWS (PwD)",
+};
+
+const seatKey = (institute, program, quota, seatType, gender) =>
+  [institute, program, quota, seatType, gender].join("");
+
+const pairKey = (institute, program) => `${institute}${program}`;
+
+const GENDER_NEUTRAL = "Gender-Neutral";
+const FEMALE_ONLY = "Female-only (including Supernumerary)";
+
+/** Female-only is an ADDITIONAL reserved pool on top of the neutral one, not
+ * a restriction to it — a female candidate is eligible for both. A
+ * Gender-Neutral profile only ever sees the neutral pool. Neutral is checked
+ * first so a female candidate's seat is reported via general merit whenever
+ * she qualifies there, falling back to the supernumerary pool only if not. */
+const genderPoolsFor = (profileGender) =>
+  profileGender === FEMALE_ONLY ? [GENDER_NEUTRAL, FEMALE_ONLY] : [profileGender];
+
+let allRoundsPromise = null;
+let collegesPromise = null;
+
+/**
+ * Fetch + decode the integer-coded all-rounds file into plain row objects.
+ * Preparatory ("P"-suffixed rank) rows are dropped here: they're a separate
+ * rank space and are never comparable to a main-list rank (see
+ * docs/SIMULATION_DATA.md). Cached in-module so repeated calls (e.g. moving
+ * between wizard steps) don't re-fetch/re-decode the 2MB file.
+ */
+export async function loadAllRoundsData() {
+  if (!allRoundsPromise) {
+    allRoundsPromise = fetch(ALL_ROUNDS_URL)
+      .then((res) => {
+        if (!res.ok) throw new Error("Could not load JoSAA round data.");
+        return res.json();
+      })
+      .then((raw) => {
+        const prepIndexes = new Set(raw.preparatory_row_indexes || []);
+        const rows = [];
+        raw.rows.forEach((r, idx) => {
+          if (prepIndexes.has(idx)) return;
+          rows.push({
+            institute: raw.institutes[r[0]],
+            program: raw.programs[r[1]],
+            quota: raw.quotas[r[2]],
+            seatType: raw.seat_types[r[3]],
+            gender: raw.genders[r[4]],
+            round: r[5],
+            openingRank: r[6],
+            closingRank: r[7],
+          });
+        });
+        return rows;
+      });
+  }
+  return allRoundsPromise;
+}
+
+/** Fetch + index colleges.json by display_name (the join key against the
+ * institute strings in the all-rounds file — verified 1:1 for all 128). */
+export async function loadCollegesData() {
+  if (!collegesPromise) {
+    collegesPromise = fetch(COLLEGES_URL)
+      .then((res) => {
+        if (!res.ok) throw new Error("Could not load college data.");
+        return res.json();
+      })
+      .then((list) => new Map(list.map((c) => [c.display_name, c])));
+  }
+  return collegesPromise;
+}
+
+/** Group decoded rows into a seat -> {round: {opening, closing}} index. */
+export function buildSeatIndex(rows) {
+  const index = new Map();
+  for (const row of rows) {
+    const key = seatKey(
+      row.institute,
+      row.program,
+      row.quota,
+      row.seatType,
+      row.gender
+    );
+    let byRound = index.get(key);
+    if (!byRound) {
+      byRound = {};
+      index.set(key, byRound);
+    }
+    byRound[row.round] = {
+      opening: row.openingRank,
+      closing: row.closingRank,
+    };
+  }
+  return index;
+}
+
+/** Which quota (AI/HS/OS/JK/GO/LA) applies to this student at this institute,
+ * or null if none of the quotas the institute actually offers match them. */
+export function resolveQuota(institute, collegesByName, homeState) {
+  const college = collegesByName.get(institute);
+  const offered = college?.programs?.quotas_offered || ["AI", "HS", "OS"];
+  for (const quota of offered) {
+    if (matchesJosaaQuota({ Quota: quota, State: college?.state }, homeState)) {
+      return quota;
+    }
+  }
+  return null;
+}
+
+/** Look up whichever gender pool actually has a seat for this
+ * institute+program at this round, respecting genderPoolsFor()'s priority
+ * (neutral before female-only). Returns null if neither pool has a row here,
+ * or if no quota this institute offers matches the student's home state. */
+function findSeatForChoice(institute, program, round, seatIndex, profile, collegesByName) {
+  const quota = resolveQuota(institute, collegesByName, profile.homeState);
+  if (!quota) return null;
+  const seatType = CATEGORY_TO_SEAT_TYPE[profile.category];
+
+  for (const gender of genderPoolsFor(profile.gender)) {
+    const seat = seatIndex.get(seatKey(institute, program, quota, seatType, gender));
+    const roundData = seat && seat[round];
+    if (roundData) {
+      return { quota, gender, opening: roundData.opening, closing: roundData.closing };
+    }
+  }
+  return null;
+}
+
+/** Which rank space an institute is compared in — JEE Advanced for IITs, JEE
+ * Main for everyone else. Two completely different candidate pools with
+ * different totals, so a rank of 3,000 in one is NOT comparable to a rank of
+ * 3,000 in the other — callers that display closing ranks across institutes
+ * (the missed-options critique) need this to avoid mixing the two scales. */
+export function examSpaceFor(institute, collegesByName) {
+  const college = collegesByName.get(institute);
+  return (college?.entrance_exams || []).includes("JEE Advanced")
+    ? "JEE Advanced"
+    : "JEE Main";
+}
+
+/** Which rank the student should be compared against for this institute.
+ * Returns null if the student doesn't have the rank this institute needs
+ * (e.g. didn't qualify JEE Advanced). */
+export function studentRankForInstitute(profile, institute, collegesByName) {
+  const needsAdvanced = examSpaceFor(institute, collegesByName) === "JEE Advanced";
+  const raw = needsAdvanced ? profile.advRank : profile.mainRank;
+  if (raw === undefined || raw === null || raw === "") return null;
+  const rank = Number(raw);
+  return Number.isFinite(rank) && rank > 0 ? rank : null;
+}
+
+/**
+ * Build the browseable catalog of Institute+Program choices available to a
+ * student's category/gender/home-state, as of Round 1 (when JoSAA choice
+ * filling actually happens — a seat that only appears from Round 2 onward
+ * was never a fillable choice).
+ */
+export function buildCatalog(rows, profile, collegesByName) {
+  const seatType = CATEGORY_TO_SEAT_TYPE[profile.category];
+  const pools = genderPoolsFor(profile.gender);
+  const byPair = new Map();
+
+  for (const row of rows) {
+    if (row.round !== 1) continue;
+    if (row.seatType !== seatType) continue;
+    if (!pools.includes(row.gender)) continue;
+
+    const quota = resolveQuota(row.institute, collegesByName, profile.homeState);
+    if (!quota || quota !== row.quota) continue;
+
+    const key = pairKey(row.institute, row.program);
+    const existing = byPair.get(key);
+    // A female candidate can have both a Gender-Neutral AND a Female-only row
+    // for the same institute+program — show the neutral one (the pool she'd
+    // actually be evaluated under first), falling back to Female-only only
+    // when that's the only pool with a Round 1 row here.
+    if (!existing || pools.indexOf(row.gender) < pools.indexOf(existing.gender)) {
+      byPair.set(key, {
+        institute: row.institute,
+        program: row.program,
+        quota,
+        gender: row.gender,
+        openingRankR1: row.openingRank,
+        closingRankR1: row.closingRank,
+      });
+    }
+  }
+
+  const catalog = Array.from(byPair.values());
+  // Alphabetical, not by cutoff — a mock is supposed to make students search
+  // and judge for themselves, the way JoSAA's own choice list does. Sorting
+  // hardest-to-easiest would hand them the difficulty ranking for free.
+  catalog.sort(
+    (a, b) => a.institute.localeCompare(b.institute) || a.program.localeCompare(b.program)
+  );
+  return catalog;
+}
+
+/** Parse "Computer Science and Engineering (4 Years, Bachelor of Technology)"
+ * into {branch, years, degree} so it can be matched against a college's
+ * programs.list entries (which carry the same fields separately). Returns
+ * null if the program string doesn't follow the expected shape. */
+function parseProgramName(programName) {
+  const match = /^(.*)\s\((\d+)\s*Years?,\s*(.*)\)$/.exec(programName || "");
+  if (!match) return null;
+  return { branch: match[1].trim(), years: Number(match[2]), degree: match[3].trim() };
+}
+
+/** Look up the branch-level indicative closing rank for a program from
+ * colleges.json (this is the one field with 128/128 coverage, unlike NIRF/
+ * salary which are college-level and only ~half-covered). */
+export function findIndicativeRank(college, programName) {
+  const parsed = parseProgramName(programName);
+  if (!parsed || !college?.programs?.list) return null;
+  const entry = college.programs.list.find(
+    (p) =>
+      p.branch === parsed.branch &&
+      p.years === parsed.years &&
+      p.degree === parsed.degree
+  );
+  return entry ? entry.indicative_closing_rank : null;
+}
+
+/** For an ordered list of choices, find the best (earliest-preference)
+ * choice the student is eligible for in a given round, or null if none.
+ * `filterFn(choice)` can narrow which choices are even considered — used by
+ * "slide" mode to restrict the search to the currently-held institute — while
+ * `index` still reflects the choice's real position in the original list, so
+ * preference comparisons against a previous round's result stay meaningful. */
+function bestEligibleAtRound(
+  choices,
+  round,
+  seatIndex,
+  profile,
+  collegesByName,
+  filterFn = () => true
+) {
+  for (let index = 0; index < choices.length; index += 1) {
+    const choice = choices[index];
+    if (!filterFn(choice)) continue;
+
+    const seat = findSeatForChoice(choice.institute, choice.program, round, seatIndex, profile, collegesByName);
+    if (!seat) continue; // no quota this institute offers matches them, or no row this round in either gender pool
+
+    const rank = studentRankForInstitute(profile, choice.institute, collegesByName);
+    if (rank == null) continue; // student lacks the rank this institute needs
+
+    if (seat.closing >= rank) {
+      return {
+        index,
+        choice,
+        round,
+        opening: seat.opening,
+        closing: seat.closing,
+        quota: seat.quota,
+        gender: seat.gender,
+      };
+    }
+  }
+  return null;
+}
+
+/** Round 1 has no "previous seat" yet — it's just the best eligible choice,
+ * same as any other exam predictor. This is where the mock's trail starts. */
+export function getRoundOneResult(choices, profile, seatIndex, collegesByName) {
+  return bestEligibleAtRound(choices, 1, seatIndex, profile, collegesByName);
+}
+
+/**
+ * Advance from a held `previousProvisional` (or null, if nothing was held
+ * yet) into `round`, under one of three real-JoSAA modes:
+ *
+ *  - "float": search the WHOLE preference list for anything ranked higher
+ *    than what's currently held — may jump to a different institute.
+ *  - "slide": search ONLY other branches at the SAME institute as the
+ *    currently-held seat — you keep your college, only the branch can
+ *    improve. Requires an existing `previousProvisional` to slide within.
+ *  - "freeze" isn't handled here — freezing just stops calling this at all.
+ *
+ * Either way the result can only improve on or match `previousProvisional`,
+ * never regress — matches the data (cutoffs loosen ~100% of the time R1→R6),
+ * so a seat once held is never taken away, only upgraded or kept.
+ */
+export function advanceRound(
+  choices,
+  profile,
+  seatIndex,
+  collegesByName,
+  round,
+  previousProvisional,
+  mode
+) {
+  const filterFn =
+    mode === "slide" && previousProvisional
+      ? (choice) => choice.institute === previousProvisional.choice.institute
+      : () => true;
+
+  const best = bestEligibleAtRound(choices, round, seatIndex, profile, collegesByName, filterFn);
+  const provisional =
+    best && (!previousProvisional || best.index < previousProvisional.index)
+      ? best
+      : previousProvisional || null;
+
+  return { round, provisional, mode };
+}
+
+/**
+ * At the final held round, find every reachable Institute+Program combo
+ * EXCEPT the one actually allotted — the pool behind the "you may have
+ * gotten a better option" critique. This deliberately does NOT exclude the
+ * student's other listed choices: a choice they ranked below what they got,
+ * that was also reachable, is exactly the "you had this and put it too low"
+ * case, and is annotated with `listPosition` (1-based) so the UI can call
+ * that out rather than presenting it as something they never considered.
+ *
+ * Each result also carries `exam` (JEE Main / JEE Advanced) — the caller
+ * must not rank-sort IIT and non-IIT results against each other on raw
+ * closing rank; the two exams' candidate pools aren't the same scale (see
+ * examSpaceFor). NIRF rank and salary don't have that problem, so those tabs
+ * can sort the full mixed list directly.
+ */
+export function findMissedBetterOptions(
+  catalog,
+  choices,
+  winningChoice,
+  round,
+  seatIndex,
+  profile,
+  collegesByName
+) {
+  const excludeKey = pairKey(winningChoice.institute, winningChoice.program);
+  const listPositionByPair = new Map(
+    choices.map((c, i) => [pairKey(c.institute, c.program), i + 1])
+  );
+  const results = [];
+
+  for (const item of catalog) {
+    const key = pairKey(item.institute, item.program);
+    if (key === excludeKey) continue;
+
+    const seat = findSeatForChoice(item.institute, item.program, round, seatIndex, profile, collegesByName);
+    if (!seat) continue;
+
+    const rank = studentRankForInstitute(profile, item.institute, collegesByName);
+    if (rank == null || seat.closing < rank) continue;
+
+    const college = collegesByName.get(item.institute);
+    results.push({
+      institute: item.institute,
+      program: item.program,
+      closingRank: seat.closing,
+      nirfRank: college?.nirf?.engineering_rank ?? null,
+      medianSalary: college?.placement?.median_salary ?? null,
+      exam: examSpaceFor(item.institute, collegesByName),
+      listPosition: listPositionByPair.get(key) ?? null,
+    });
+  }
+
+  return results;
+}
+
+export { TOTAL_ROUNDS };


### PR DESCRIPTION
## Summary

Adds a self-contained practice tool at `/mock-allotment` that lets a student go through JoSAA's actual choice-filling → locking → freeze/float/slide process end-to-end, using real 2025 cutoff data instead of a live/synthetic feed. No new datasets, no backend — built entirely on data already merged in from `simulation-data` (`josaa_2025_all_rounds.json`, `colleges.json`) plus the existing `josaaConfig`/`matchesJosaaQuota` from the live predictor.

> **Base branch note:** this stacks on `simulation-data` (not `main`) — that branch isn't merged upstream yet, and this PR's data dependency requires it.

## Why

Students filling real JoSAA choices for the first time have no way to rehearse the mechanics — preference ordering, the freeze/float/slide decision each round, or seeing how a poorly-ordered list costs them a better seat — without risking it on the actual counselling. This gives them a sandbox that behaves like the real process closely enough to build the right instincts, while being explicit about where it's an approximation.

## What's in the flow

1. **Student Info** — category, gender, home state, JEE Main rank, optional JEE Advanced rank (reuses `josaaConfig` fields, no new UI vocabulary).
2. **Choice Filling** — search/filter the full eligible catalog (quota- and category-correct for the student), add choices, reorder them immediately via drag, ↑/↓ buttons, or typing a position number.
3. **Review & Manage** — same reordering, plus lock/unlock.
4. **Simulation** — round-by-round (1–6), the student chooses:
   - **Freeze** — stop and keep this seat.
   - **Float** — recheck the whole list for anything better, at any institute.
   - **Slide** — recheck only other branches at the currently-held institute.

   Ends with a "you may have gotten a better option" critique across three tabs — **Closing Rank**, **NIRF Ranking**, and **Median Salary** — each with its own reliability caveat.

Cutoffs are deliberately **not shown during choice-filling** — seeing which seats are "easy" before building the list defeats the point of practicing; real JoSAA doesn't show it either.

## Implementation notes

### `utils/josaaSimulator.js`

All eligibility/simulation logic is decoupled from React:

- Decodes the integer-coded `josaa_2025_all_rounds.json` (lookup-array + index-row format) and drops preparatory-rank rows, which live in a separate, non-comparable rank space.
- Reuses `examConfig.js`'s `matchesJosaaQuota` (now exported) for AI/HS/OS/JK/GO/LA resolution, rather than maintaining a second copy that could drift.
- **Gender-pool fix:** a Female-only profile is eligible for the Gender-Neutral pool too (it is an additional reservation, not a restriction). Gender-Neutral is checked first, falling back to Female-only. Verified that the Female-only catalog is a strict superset of the Gender-Neutral one against the real data.
- **Rank-space separation:** IITs compare against JEE Advanced rank, while everyone else compares against JEE Main. This is resolved from `colleges.json`'s `entrance_exams`. Confirmed no institute needs both.
- Freeze/Float/Slide is interactive per round (`getRoundOneResult` + `advanceRound(mode)`), rather than a precomputed six-round trace, since the mode chosen changes what is checked next round.
- The "better option" critique excludes only the seat actually allotted — not the student's whole list — so a choice they had but ranked too low correctly surfaces, annotated with its original list position.
- Closing-rank comparisons across JEE Main and JEE Advanced institutes are never merged into one sorted list because they represent different candidate pools and the numbers are not comparable. They are shown as two separate groups.
- NIRF and salary tabs remain merged since these are normalized signals.

### `components/MockAllotment.js`

New wizard UI:

- State is stored in `localStorage` under `josaaMockAllotmentState_v2`.
- No backend required.
- `ReorderableChoiceList` is a single shared component used in both Choice Filling and Review — not duplicated.
- Supports:
  - Pointer Events for mouse + touch + pen
  - ↑/↓ buttons
  - Type-to-jump
  - Drag-and-drop
- Drag-and-drop had an off-by-one bug during development where dropping "just before the last item" and "past everything" were indistinguishable.
- Fixed using explicit gap-index semantics and verified against 9 hand-checked reorder cases.
- Pointer Events do not provide a native drag ghost like the HTML5 drag API, so a floating label follows the cursor/finger during dragging to keep the item visible.

### `examConfig.js`

One-line change:

- Exported `matchesJosaaQuota`, which was previously private.

### `components/navbar.js`

- Added a **Mock Allotment** navigation link.

## Known limitations

Called out explicitly in the UI:

- **Single-year snapshot:** 2025 data only; no multi-year trend.
- **NIRF and median salary:** These are college-level, not branch-level. The underlying data explicitly marks this with `is_branch_specific: false`.
- **Nationality/OCI:** The underlying dataset does not contain nationality/OCI data, so the simulator is implicitly Indian-nationals-only, consistent with the live predictor.
- **Drag-and-drop:** Native Pointer Events support mouse, touch, and pen, so no separate fallback is needed.


Verified:

- Quota resolution
- Exam-space separation
- Round-by-round monotonicity
- Freeze/Float/Slide divergence
- Synthetic scenario proving Slide never crosses institutes while Float does
- Gender-pool superset property
- Missed-options exclusion
- Original list-position annotation
- Exam tagging

