### PR TITLE
OJEE: repair overprinted programme/institute text

### DIFF
--- a/public/data/OJEE/ojee_data.json
+++ b/public/data/OJEE/ojee_data.json
@@ -2,7 +2,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -46,7 +46,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -57,7 +57,7 @@
  {
   "Institute": "Veer Surendra Sai University of Technology, Burla",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -68,7 +68,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "InformationTechnology(SSC) - TFW",
+  "Academic Program Name": "Information Technology(SSC) - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -79,7 +79,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -101,7 +101,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -134,7 +134,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Communication Engineeirng - TFW",
+  "Academic Program Name": "Electronics & Communication Engineering - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -145,7 +145,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "InformationTechnology(SSC)",
+  "Academic Program Name": "Information Technology(SSC)",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -233,7 +233,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Communication Engineeirng",
+  "Academic Program Name": "Electronics & Communication Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -266,7 +266,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "InformationTechnology(SSC)",
+  "Academic Program Name": "Information Technology(SSC)",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -277,7 +277,7 @@
  {
   "Institute": "Veer Surendra Sai University of Technology, Burla",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -299,7 +299,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetric la Engineering - TFW",
+  "Academic Program Name": "Electrical Engineering - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -310,7 +310,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "InformationTechnology(SSC)",
+  "Academic Program Name": "Information Technology(SSC)",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -321,7 +321,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "MechanicalE ngineering (Artificial Intelligence and Robotics) - TFW",
+  "Academic Program Name": "Mechanical Engineering (Artificial Intelligence and Robotics) - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -343,7 +343,7 @@
  {
   "Institute": "Veer Surendra Sai University of Technology, Burla",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -354,7 +354,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "EW",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -376,7 +376,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Instrumentation Engineering - TFW",
+  "Academic Program Name": "Electronics & Instrumentation Engineering - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -409,7 +409,7 @@
  {
   "Institute": "Veer Surendra Sai University of Technology, Burla",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -420,7 +420,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Communication Engineeirng",
+  "Academic Program Name": "Electronics & Communication Engineering",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -453,7 +453,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Communication Engineeirng",
+  "Academic Program Name": "Electronics & Communication Engineering",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -563,7 +563,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetric la Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -585,7 +585,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "InformationTechnology(SSC)",
+  "Academic Program Name": "Information Technology(SSC)",
   "Category": "EW",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -607,7 +607,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Instrumentation Engineering",
+  "Academic Program Name": "Electronics & Instrumentation Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -618,7 +618,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Instrumentation Engineering",
+  "Academic Program Name": "Electronics & Instrumentation Engineering",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -651,7 +651,7 @@
  {
   "Institute": "Veer Surendra Sai University of Technology, Burla",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "EW",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -662,7 +662,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "MechanicalE ngg.( Artificial Intelligence and Robotics)",
+  "Academic Program Name": "Mechanical Engineering (Artificial Intelligence and Robotics)",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -695,7 +695,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetric la Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -706,7 +706,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -739,7 +739,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "MechanicalE ngg.( Artificial Intelligence and Robotics)",
+  "Academic Program Name": "Mechanical Engineering (Artificial Intelligence and Robotics)",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -750,7 +750,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetric la Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "EW",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -772,7 +772,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Instrumentation Engineering",
+  "Academic Program Name": "Electronics & Instrumentation Engineering",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -794,7 +794,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "MechanicalE ngg.( Artificial Intelligence and Robotics)",
+  "Academic Program Name": "Mechanical Engineering (Artificial Intelligence and Robotics)",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -838,7 +838,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetric la Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -880,9 +880,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Information and Cyber Security (SSC) - TF",
+  "Academic Program Name": "Computer Science Engineering with specialization in Information and Cyber Security (SSC) - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -893,7 +893,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Communication Engineeirng",
+  "Academic Program Name": "Electronics & Communication Engineering",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -904,7 +904,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "InformationTechnology(SSC)",
+  "Academic Program Name": "Information Technology(SSC)",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -915,7 +915,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "SC",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -970,7 +970,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Communication Engineeirng",
+  "Academic Program Name": "Electronics & Communication Engineering",
   "Category": "EW",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -1102,7 +1102,7 @@
  {
   "Institute": "Veer Surendra Sai University of Technology, Burla",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -1289,7 +1289,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "MechanicalE ngg.( Artificial Intelligence and Robotics)",
+  "Academic Program Name": "Mechanical Engineering (Artificial Intelligence and Robotics)",
   "Category": "EW",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -1377,7 +1377,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Instrumentation Engineering",
+  "Academic Program Name": "Electronics & Instrumentation Engineering",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -1465,7 +1465,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetric la Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -1487,7 +1487,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Metallugr ical and Materials Engineering - TFW",
+  "Academic Program Name": "Metallurgical and Materials Engineering - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -1542,7 +1542,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "MechanicalE ngg.( Artificial Intelligence and Robotics)",
+  "Academic Program Name": "Mechanical Engineering (Artificial Intelligence and Robotics)",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -1597,7 +1597,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "InformationTechnology(SSC)",
+  "Academic Program Name": "Information Technology(SSC)",
   "Category": "SC",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -1727,9 +1727,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -1740,7 +1740,7 @@
  {
   "Institute": "Veer Surendra Sai University of Technology, Burla",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "SC",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -1894,7 +1894,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Instrumentation Engineering",
+  "Academic Program Name": "Electronics & Instrumentation Engineering",
   "Category": "EW",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -1938,7 +1938,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Communication Engineeirng",
+  "Academic Program Name": "Electronics & Communication Engineering",
   "Category": "SC",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -1960,7 +1960,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Metallugr ical and Materials Engineering",
+  "Academic Program Name": "Metallurgical and Materials Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -2037,7 +2037,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Metallugr ical and Materials Engineering",
+  "Academic Program Name": "Metallurgical and Materials Engineering",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -2136,7 +2136,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Metallugr ical and Materials Engineering",
+  "Academic Program Name": "Metallurgical and Materials Engineering",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -2213,7 +2213,7 @@
  {
   "Institute": "Veer Surendra Sai University of Technology, Burla",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "ST",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -2464,9 +2464,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science and Engineering(SSC) - TFW",
+  "Academic Program Name": "Computer Science and Engineering(SSC) - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -2664,7 +2664,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "ST",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -2686,7 +2686,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetric la Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "SC",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -2717,9 +2717,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Information and Cyber Security (SSC)",
+  "Academic Program Name": "Computer Science Engineering with specialization in Information and Cyber Security (SSC)",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -2763,7 +2763,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Metallugr ical and Materials Engineering",
+  "Academic Program Name": "Metallurgical and Materials Engineering",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -2785,7 +2785,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Metallugr ical and Materials Engineering",
+  "Academic Program Name": "Metallurgical and Materials Engineering",
   "Category": "SC",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -2928,7 +2928,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "MechanicalE ngg.( Artificial Intelligence and Robotics)",
+  "Academic Program Name": "Mechanical Engineering (Artificial Intelligence and Robotics)",
   "Category": "SC",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -2981,9 +2981,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BEulerlcatronics & Communication Engineering(SSC) - TFW",
+  "Academic Program Name": "Electronics & Communication Engineering(SSC) - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -3071,7 +3071,7 @@
  {
   "Institute": "Veer Surendra Sai University of Technology, Burla",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "ST",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -3102,9 +3102,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Information and Cyber Security (SSC)",
+  "Academic Program Name": "Computer Science Engineering with specialization in Information and Cyber Security (SSC)",
   "Category": "ST",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -3203,7 +3203,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Instrumentation Engineering",
+  "Academic Program Name": "Electronics & Instrumentation Engineering",
   "Category": "SC",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -3280,7 +3280,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Txetlie Engineering - TFW",
+  "Academic Program Name": "Textile Engineering - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -3357,7 +3357,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "ST",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -3434,7 +3434,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Integrated MSc in AppliedPhysics",
+  "Academic Program Name": "Integrated MSc in Applied Physics",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -3500,7 +3500,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Txetlie Engineering",
+  "Academic Program Name": "Textile Engineering",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -3531,9 +3531,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "SC",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -3544,7 +3544,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "InformationTechnology(SSC)",
+  "Academic Program Name": "Information Technology(SSC)",
   "Category": "ST",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -3654,7 +3654,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Integrated MSc in AppliedPhysics",
+  "Academic Program Name": "Integrated MSc in Applied Physics",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -3742,7 +3742,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Mr echanical Engineering",
+  "Academic Program Name": "Mechanical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -3795,9 +3795,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -3830,7 +3830,7 @@
  {
   "Institute": "Eastern Academy of Science and Technology, Phulanakhara, Bhubanes",
   "State": "Odisha",
-  "Academic Program Name": "wEalerctronics & Telecommunication Engineering",
+  "Academic Program Name": "Electronics & Telecommunication Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -4037,9 +4037,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -4105,7 +4105,7 @@
  {
   "Institute": "Central Institute of Plastic Engineering and Technology, Patia, Bhubane",
   "State": "Odisha",
-  "Academic Program Name": "sPwlaasrtic Engineering - TFW",
+  "Academic Program Name": "Plastic Engineering - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -4149,7 +4149,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Txetlie Engineering",
+  "Academic Program Name": "Textile Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -4224,9 +4224,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -4444,9 +4444,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BEulerlcatrical and Electronics Engineering(SSC) - TFW",
+  "Academic Program Name": "Electrical and Electronics Engineering(SSC) - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -4556,7 +4556,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Communication Engineeirng",
+  "Academic Program Name": "Electronics & Communication Engineering",
   "Category": "ST",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -4653,9 +4653,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Information and Cyber Security (SSC)",
+  "Academic Program Name": "Computer Science Engineering with specialization in Information and Cyber Security (SSC)",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -4686,9 +4686,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science and Engineering(SSC)",
+  "Academic Program Name": "Computer Science and Engineering(SSC)",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -4763,9 +4763,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BEulerlcatronics & Communication Engineering(SSC)",
+  "Academic Program Name": "Electronics & Communication Engineering(SSC)",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -4842,7 +4842,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "MechanicalE ngg.( Artificial Intelligence and Robotics)",
+  "Academic Program Name": "Mechanical Engineering (Artificial Intelligence and Robotics)",
   "Category": "ST",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -4983,9 +4983,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science and Engineering(SSC)",
+  "Academic Program Name": "Computer Science and Engineering(SSC)",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -5062,7 +5062,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetric la Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "ST",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -5170,9 +5170,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science and Engineering(SSC)",
+  "Academic Program Name": "Computer Science and Engineering(SSC)",
   "Category": "EW",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -5238,7 +5238,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Integrated MSc in AppliedPhysics",
+  "Academic Program Name": "Integrated MSc in Applied Physics",
   "Category": "ST",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -5291,9 +5291,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BEulerlcatronics & Communication Engineering(SSC)",
+  "Academic Program Name": "Electronics & Communication Engineering(SSC)",
   "Category": "EW",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -5304,7 +5304,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rComputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -5313,9 +5313,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Information and Cyber Security (SSC)",
+  "Academic Program Name": "Computer Science Engineering with specialization in Information and Cyber Security (SSC)",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -5447,7 +5447,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aComputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -5524,7 +5524,7 @@
  {
   "Institute": "Eastern Academy of Science and Technology, Phulanakhara, Bhubanes",
   "State": "Odisha",
-  "Academic Program Name": "wEanrvironmental Engineering",
+  "Academic Program Name": "Environmental Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -5533,9 +5533,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "ST",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -5566,9 +5566,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Balaji Institute of Technology & Science, Knowledge Centre, Gunupur,",
+  "Institute": "Balaji Institute of Technology & Science, Knowledge Centre, Gunupur, Rayagada",
   "State": "Odisha",
-  "Academic Program Name": "RCaoymagpaudtaer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -5623,7 +5623,7 @@
  {
   "Institute": "Bhubaneswar Institute of Industrial Technology, Retanga, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rMining Engineering - TFW",
+  "Academic Program Name": "Mining Engineering - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -5874,9 +5874,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Information and Cyber Security (SSC)",
+  "Academic Program Name": "Computer Science Engineering with specialization in Information and Cyber Security (SSC)",
   "Category": "SC",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -5931,7 +5931,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Metallugr ical and Materials Engineering",
+  "Academic Program Name": "Metallurgical and Materials Engineering",
   "Category": "EW",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -5975,7 +5975,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "MechanicalE ngg.( Artificial Intelligence and Robotics)",
+  "Academic Program Name": "Mechanical Engineering (Artificial Intelligence and Robotics)",
   "Category": "ST",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -6052,7 +6052,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Instrumentation Engineering",
+  "Academic Program Name": "Electronics & Instrumentation Engineering",
   "Category": "ST",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -6096,7 +6096,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rArtificial Intelligence & Machine Learning",
+  "Academic Program Name": "Artificial Intelligence & Machine Learning",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -6250,7 +6250,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Txetlie Engineering",
+  "Academic Program Name": "Textile Engineering",
   "Category": "EW",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -6327,7 +6327,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Cromputer science & Engineering (Data Science)",
+  "Academic Program Name": "Computer science & Engineering (Data Science)",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -6382,7 +6382,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Txetlie Engineering",
+  "Academic Program Name": "Textile Engineering",
   "Category": "SC",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -6512,9 +6512,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science and Engineering(SSC)",
+  "Academic Program Name": "Computer Science and Engineering(SSC)",
   "Category": "ST",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -6523,9 +6523,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science and Engineering(SSC)",
+  "Academic Program Name": "Computer Science and Engineering(SSC)",
   "Category": "SC",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -6536,7 +6536,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "OL",
@@ -6635,7 +6635,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "InformationTechnology(SSC)",
+  "Academic Program Name": "Information Technology(SSC)",
   "Category": "ST",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -6657,7 +6657,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aComputer science & Engineering (Data Science) - TFW",
+  "Academic Program Name": "Computer science & Engineering (Data Science) - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -6734,7 +6734,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Txetlie Engineering",
+  "Academic Program Name": "Textile Engineering",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -6745,7 +6745,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Crivil Engineering",
+  "Academic Program Name": "Civil Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -6809,9 +6809,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science and Engineering(SSC)",
+  "Academic Program Name": "Computer Science and Engineering(SSC)",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -6855,7 +6855,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetronics & Communication Engineeirng",
+  "Academic Program Name": "Electronics & Communication Engineering",
   "Category": "ST",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -6987,7 +6987,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aComputer science & Engineering (Data Science)",
+  "Academic Program Name": "Computer science & Engineering (Data Science)",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -7073,9 +7073,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science and Engineering(SSC)",
+  "Academic Program Name": "Computer Science and Engineering(SSC)",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -7097,7 +7097,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Erlectrical Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -7152,7 +7152,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Txetlie Engineering",
+  "Academic Program Name": "Textile Engineering",
   "Category": "SC",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -7361,7 +7361,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aCivil Engineering",
+  "Academic Program Name": "Civil Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -7447,9 +7447,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Information and Cyber Security (SSC)",
+  "Academic Program Name": "Computer Science Engineering with specialization in Information and Cyber Security (SSC)",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -7526,7 +7526,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aCivil Engineering",
+  "Academic Program Name": "Civil Engineering",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -7570,7 +7570,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Elcetric la Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "ST",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -7744,9 +7744,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BEulerlcatronics & Communication Engineering(SSC)",
+  "Academic Program Name": "Electronics & Communication Engineering(SSC)",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -7876,9 +7876,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BEulerlcatronics & Communication Engineering(SSC)",
+  "Academic Program Name": "Electronics & Communication Engineering(SSC)",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -8140,9 +8140,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BEulerlcatrical and Electronics Engineering(SSC)",
+  "Academic Program Name": "Electrical and Electronics Engineering(SSC)",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -8296,7 +8296,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aElectronics & Communication Engineering",
+  "Academic Program Name": "Electronics & Communication Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -8703,7 +8703,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Metallugr ical and Materials Engineering",
+  "Academic Program Name": "Metallurgical and Materials Engineering",
   "Category": "ST",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -8714,7 +8714,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aMechanical Engineering",
+  "Academic Program Name": "Mechanical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -9143,7 +9143,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rArtificial Intelligence & Machine Learning",
+  "Academic Program Name": "Artificial Intelligence & Machine Learning",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "OS",
@@ -9297,7 +9297,7 @@
  {
   "Institute": "Bhubaneswar Institute of Industrial Technology, Retanga, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rMining Engineering",
+  "Academic Program Name": "Mining Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -9330,7 +9330,7 @@
  {
   "Institute": "Bhubaneswar Institute of Industrial Technology, Retanga, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rMechanical Engineering",
+  "Academic Program Name": "Mechanical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -9770,7 +9770,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rMechanical Engineering",
+  "Academic Program Name": "Mechanical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -9803,7 +9803,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rCivil Engineering",
+  "Academic Program Name": "Civil Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -10065,9 +10065,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Information and Cyber Security (SSC)",
+  "Academic Program Name": "Computer Science Engineering with specialization in Information and Cyber Security (SSC)",
   "Category": "ST",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -10153,9 +10153,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BEulerlcatrical and Electronics Engineering(SSC)",
+  "Academic Program Name": "Electrical and Electronics Engineering(SSC)",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -10199,7 +10199,7 @@
  {
   "Institute": "Bhubaneswar Institute of Industrial Technology, Retanga, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rCivil Engineering",
+  "Academic Program Name": "Civil Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -10309,7 +10309,7 @@
  {
   "Institute": "Bhubaneswar Institute of Industrial Technology, Retanga, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rComputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -10364,7 +10364,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aComputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -10375,7 +10375,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aElectrical Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -10441,7 +10441,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Cromputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -10518,7 +10518,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rElectrical and Electronics Engineering",
+  "Academic Program Name": "Electrical and Electronics Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -10639,7 +10639,7 @@
  {
   "Institute": "Central Institute of Plastic Engineering and Technology, Patia, Bhubane",
   "State": "Odisha",
-  "Academic Program Name": "sPwlaasrtic Engineering",
+  "Academic Program Name": "Plastic Engineering",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -10650,7 +10650,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aElectrical and Electronics Engineering",
+  "Academic Program Name": "Electrical and Electronics Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -10661,7 +10661,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rComputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -10760,7 +10760,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aComputer science & Engineering (Data Science)",
+  "Academic Program Name": "Computer science & Engineering (Data Science)",
   "Category": "General",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -10837,7 +10837,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aCivil Engineering - TFW",
+  "Academic Program Name": "Civil Engineering - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -11112,7 +11112,7 @@
  {
   "Institute": "Odisha University of Technology and Research (formerly College of Engineering and Technology), Bhubaneswar",
   "State": "Odisha",
-  "Academic Program Name": "Metallugr ical and Materials Engineering",
+  "Academic Program Name": "Metallurgical and Materials Engineering",
   "Category": "ST",
   "Seat Type": "Female Only",
   "Quota": "HS",
@@ -11145,7 +11145,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aComputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "OS",
@@ -11156,7 +11156,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rElectrical Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -11178,7 +11178,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Cromputer Science Engineering (Artificial Inteligence and Machine Learning)",
+  "Academic Program Name": "Computer Science Engineering (Artificial Inteligence and Machine Learning)",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "AI",
@@ -11376,7 +11376,7 @@
  {
   "Institute": "Central Institute of Plastic Engineering and Technology, Patia, Bhubane",
   "State": "Odisha",
-  "Academic Program Name": "sMwaanrufacturing Engineering & Technology - TFW",
+  "Academic Program Name": "Manufacturing Engineering & Technology - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -11396,9 +11396,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BCuormlaputer Science Engineering with specialization in Artificial Intelligence and Machine Learni",
+  "Academic Program Name": "Computer Science Engineering with specialization in Artificial Intelligence and Machine Learning",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -11440,9 +11440,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BEulerlcatronics & Communication Engineering(SSC)",
+  "Academic Program Name": "Electronics & Communication Engineering(SSC)",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -11629,7 +11629,7 @@
  {
   "Institute": "Eastern Academy of Science and Technology, Phulanakhara, Bhubanes",
   "State": "Odisha",
-  "Academic Program Name": "wEanrvironmental Engineering",
+  "Academic Program Name": "Environmental Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -11684,7 +11684,7 @@
  {
   "Institute": "Samanta Chandra Sekhar Institute of Technology and Management, Se",
   "State": "Odisha",
-  "Academic Program Name": "mElielicgturdoanics & Communication Engineering",
+  "Academic Program Name": "Electronics & Communication Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -11728,7 +11728,7 @@
  {
   "Institute": "Samanta Chandra Sekhar Institute of Technology and Management, Se",
   "State": "Odisha",
-  "Academic Program Name": "mCiivliigl uEdnagineering",
+  "Academic Program Name": "Civil Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -11794,7 +11794,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rComputer Science and Engineering - TFW",
+  "Academic Program Name": "Computer Science and Engineering - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12047,7 +12047,7 @@
  {
   "Institute": "Central Institute of Plastic Engineering and Technology, Patia, Bhubane",
   "State": "Odisha",
-  "Academic Program Name": "sPwlaasrtic Engineering",
+  "Academic Program Name": "Plastic Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12067,9 +12067,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Balaji Institute of Technology & Science, Knowledge Centre, Gunupur,",
+  "Institute": "Balaji Institute of Technology & Science, Knowledge Centre, Gunupur, Rayagada",
   "State": "Odisha",
-  "Academic Program Name": "RMayeacghaadnaical Engineering - TFW",
+  "Academic Program Name": "Mechanical Engineering - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12091,7 +12091,7 @@
  {
   "Institute": "Central Institute of Plastic Engineering and Technology, Patia, Bhubane",
   "State": "Odisha",
-  "Academic Program Name": "sMwaanrufacturing Engineering & Technology",
+  "Academic Program Name": "Manufacturing Engineering & Technology",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12102,7 +12102,7 @@
  {
   "Institute": "Central Institute of Plastic Engineering and Technology, Patia, Bhubane",
   "State": "Odisha",
-  "Academic Program Name": "sInwtaergrated M.Sc. in Material Science and Engg",
+  "Academic Program Name": "Integrated M.Sc. in Material Science and Engg",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12190,7 +12190,7 @@
  {
   "Institute": "Eastern Academy of Science and Technology, Phulanakhara, Bhubanes",
   "State": "Odisha",
-  "Academic Program Name": "wEalerctrical Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12234,7 +12234,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rElectrical Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12267,7 +12267,7 @@
  {
   "Institute": "Samanta Chandra Sekhar Institute of Technology and Management, Se",
   "State": "Odisha",
-  "Academic Program Name": "mMileigcuhdanaical Engineering",
+  "Academic Program Name": "Mechanical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12289,7 +12289,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aElectronics & Communication Engineering - TFW",
+  "Academic Program Name": "Electronics & Communication Engineering - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12410,7 +12410,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aComputer Science and Engineering - TFW",
+  "Academic Program Name": "Computer Science and Engineering - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12586,7 +12586,7 @@
  {
   "Institute": "Bhubaneswar Institute of Industrial Technology, Retanga, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rMechanical Engineering",
+  "Academic Program Name": "Mechanical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12619,7 +12619,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aElectrical and Electronics Engineering",
+  "Academic Program Name": "Electrical and Electronics Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12630,7 +12630,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Argriculture Engineering",
+  "Academic Program Name": "Agriculture Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12663,7 +12663,7 @@
  {
   "Institute": "Samanta Chandra Sekhar Institute of Technology and Management, Se",
   "State": "Odisha",
-  "Academic Program Name": "mCoilimgupduater Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12707,7 +12707,7 @@
  {
   "Institute": "Eastern Academy of Science and Technology, Phulanakhara, Bhubanes",
   "State": "Odisha",
-  "Academic Program Name": "wEalerctronics & Telecommunication Engineering",
+  "Academic Program Name": "Electronics & Telecommunication Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12784,7 +12784,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Cromputer science & Engineering (Data Science)",
+  "Academic Program Name": "Computer science & Engineering (Data Science)",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12883,7 +12883,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Cromputer Science Engineering (Artificial Inteligence and Machine Learning) - TFW",
+  "Academic Program Name": "Computer Science Engineering (Artificial Inteligence and Machine Learning) - TFW",
   "Category": "TFW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12914,9 +12914,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar,",
+  "Institute": "Sambalpur University Institute of Information Technology, Jyoti Vihar, Burla",
   "State": "Odisha",
-  "Academic Program Name": "BEulerlcatrical and Electronics Engineering(SSC)",
+  "Academic Program Name": "Electrical and Electronics Engineering(SSC)",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -12960,7 +12960,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aComputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -13301,7 +13301,7 @@
  {
   "Institute": "Bhubaneswar Institute of Industrial Technology, Retanga, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rComputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -13312,7 +13312,7 @@
  {
   "Institute": "KALLINGA GLOBAL INSTITUTE OF TECHNOLOGY, INNOVATION & MANAGEMENT,JAJPUR",
   "State": "Odisha",
-  "Academic Program Name": "lEectrical Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -13378,7 +13378,7 @@
  {
   "Institute": "Eastern Academy of Science and Technology, Phulanakhara, Bhubanes",
   "State": "Odisha",
-  "Academic Program Name": "wCaivril Engineering",
+  "Academic Program Name": "Civil Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -13818,7 +13818,7 @@
  {
   "Institute": "Bhubaneswar Institute of Industrial Technology, Retanga, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rMetallurgical Engineering",
+  "Academic Program Name": "Metallurgical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -13939,7 +13939,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Cromputer Science Engineering (Artificial Inteligence and Machine Learning)",
+  "Academic Program Name": "Computer Science Engineering (Artificial Inteligence and Machine Learning)",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -14060,7 +14060,7 @@
  {
   "Institute": "Bhubaneswar Institute of Industrial Technology, Retanga, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rCivil Engineering",
+  "Academic Program Name": "Civil Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -14137,7 +14137,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rMechanical Engineering",
+  "Academic Program Name": "Mechanical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -14236,7 +14236,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Crivil Engineering",
+  "Academic Program Name": "Civil Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -14533,7 +14533,7 @@
  {
   "Institute": "Eastern Academy of Science and Technology, Phulanakhara, Bhubanes",
   "State": "Odisha",
-  "Academic Program Name": "wCaormputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -14577,7 +14577,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aElectronics & Communication Engineering",
+  "Academic Program Name": "Electronics & Communication Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -14731,7 +14731,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rArtificial Intelligence & Machine Learning",
+  "Academic Program Name": "Artificial Intelligence & Machine Learning",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -14938,9 +14938,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Balaji Institute of Technology & Science, Knowledge Centre, Gunupur,",
+  "Institute": "Balaji Institute of Technology & Science, Knowledge Centre, Gunupur, Rayagada",
   "State": "Odisha",
-  "Academic Program Name": "RCaiyvailg Eandgaineering",
+  "Academic Program Name": "Civil Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -14951,7 +14951,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aElectrical Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -15083,7 +15083,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Cromputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -15303,7 +15303,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rElectrical and Electronics Engineering",
+  "Academic Program Name": "Electrical and Electronics Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -15380,7 +15380,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rCivil Engineering",
+  "Academic Program Name": "Civil Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -15391,7 +15391,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Erlectrical Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -15422,9 +15422,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Balaji Institute of Technology & Science, Knowledge Centre, Gunupur,",
+  "Institute": "Balaji Institute of Technology & Science, Knowledge Centre, Gunupur, Rayagada",
   "State": "Odisha",
-  "Academic Program Name": "REalyeacgtraidcaal Engineering",
+  "Academic Program Name": "Electrical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -15435,7 +15435,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Mr echanical Engineering",
+  "Academic Program Name": "Mechanical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -15468,7 +15468,7 @@
  {
   "Institute": "Bhubaneswar Institute of Industrial Technology, Retanga, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rMining Engineering",
+  "Academic Program Name": "Mining Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -15534,7 +15534,7 @@
  {
   "Institute": "Temple City Institute of Technology and Engineering,TITE, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "Erlectronics & Communication Engineering",
+  "Academic Program Name": "Electronics & Communication Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -15862,9 +15862,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Balaji Institute of Technology & Science, Knowledge Centre, Gunupur,",
+  "Institute": "Balaji Institute of Technology & Science, Knowledge Centre, Gunupur, Rayagada",
   "State": "Odisha",
-  "Academic Program Name": "RMayeacghaadnaical Engineering",
+  "Academic Program Name": "Mechanical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -15886,7 +15886,7 @@
  {
   "Institute": "Gandhi Institute of Technology and Management GITAM, Bhubaneswa",
   "State": "Odisha",
-  "Academic Program Name": "rComputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -16150,7 +16150,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aCivil Engineering",
+  "Academic Program Name": "Civil Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -16183,7 +16183,7 @@
  {
   "Institute": "Eastern Academy of Science and Technology, Phulanakhara, Bhubanes",
   "State": "Odisha",
-  "Academic Program Name": "wMaerchanical Engineering",
+  "Academic Program Name": "Mechanical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -16304,7 +16304,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aMechanical Engineering",
+  "Academic Program Name": "Mechanical Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -16469,7 +16469,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aComputer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "EW",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -16491,7 +16491,7 @@
  {
   "Institute": "Einstein Academy of Technology and Management, Baniatangi, Khordh",
   "State": "Odisha",
-  "Academic Program Name": "aComputer science & Engineering (Data Science)",
+  "Academic Program Name": "Computer science & Engineering (Data Science)",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",
@@ -16665,9 +16665,9 @@
   "Year": "2025"
  },
  {
-  "Institute": "Balaji Institute of Technology & Science, Knowledge Centre, Gunupur,",
+  "Institute": "Balaji Institute of Technology & Science, Knowledge Centre, Gunupur, Rayagada",
   "State": "Odisha",
-  "Academic Program Name": "RCaoymagpaudtaer Science and Engineering",
+  "Academic Program Name": "Computer Science and Engineering",
   "Category": "General",
   "Seat Type": "Gender Neutral",
   "Quota": "HS",


### PR DESCRIPTION
Data-only fix: 216 rows of the OJEE table carried text corrupted by the source PDF's overprinting (institute names interleaved into programme names — 'BCuormlaputer Science and Engineering', 'aCivil Engineering'). Rebuilt from the fixed parser in avantifellows/external_data_sources#101. All ranks, categories, quotas and TFW flags are byte-identical; only text is repaired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)