### PR TITLE
College branches link to careers; build inputs versioned in-repo

### DIFF
--- a/pages/colleges.js
+++ b/pages/colleges.js
@@ -246,7 +246,18 @@ const CollegeRow = ({ c, index, expanded, onToggle }) => {
                               className="border-t border-[#f0e6e1]"
                             >
                               <td className="px-2 py-1.5 text-[#332724]">
-                                {p.branch}
+                                {/* a branch is a door to a career — link it
+                                    when we know which one */}
+                                {p.career_id ? (
+                                  <Link
+                                    href={`/careers#${p.career_id}`}
+                                    className="underline decoration-[#e3d1cb] underline-offset-2 transition hover:text-[#8f2e31] hover:decoration-[#8f2e31]"
+                                  >
+                                    {p.branch}
+                                  </Link>
+                                ) : (
+                                  p.branch
+                                )}
                               </td>
                               <td className="px-2 py-1.5 text-[#6d5550]">
                                 {p.degree}

--- a/public/data/careers/careers.json
+++ b/public/data/careers/careers.json
@@ -3101,12 +3101,12 @@
     "href": "/?exam=TNEA"
    },
    {
-    "label": "DAT-Mains",
-    "href": "/exams?q=DAT-Mains"
-   },
-   {
     "label": "UCEED",
     "href": "/exams?q=UCEED"
+   },
+   {
+    "label": "DAT-Mains",
+    "href": "/exams?q=DAT-Mains"
    }
   ],
   "top_colleges": [
@@ -3279,12 +3279,12 @@
     "href": "/exams?q=JEE Advanced"
    },
    {
-    "label": "ISI-AT",
-    "href": "/exams?q=ISI-AT"
-   },
-   {
     "label": "CUET",
     "href": "/exams?q=CUET"
+   },
+   {
+    "label": "ISI-AT",
+    "href": "/exams?q=ISI-AT"
    }
   ],
   "top_colleges": [
@@ -4706,12 +4706,12 @@
     "href": "/exams?q=JEE Advanced"
    },
    {
-    "label": "MHT-CET",
-    "href": "/exams?q=MHT-CET"
-   },
-   {
     "label": "KEA-CET",
     "href": "/exams?q=KEA-CET"
+   },
+   {
+    "label": "MHT-CET",
+    "href": "/exams?q=MHT-CET"
    }
   ],
   "top_colleges": [
@@ -5815,12 +5815,12 @@
     "href": "/exams?q=JEE Advanced"
    },
    {
-    "label": "ISI-AT",
-    "href": "/exams?q=ISI-AT"
-   },
-   {
     "label": "CUET",
     "href": "/exams?q=CUET"
+   },
+   {
+    "label": "ISI-AT",
+    "href": "/exams?q=ISI-AT"
    },
    {
     "label": "CMI-EE",

--- a/public/data/colleges/colleges.json
+++ b/public/data/colleges/colleges.json
@@ -36,103 +36,120 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 171
+     "indicative_closing_rank": 171,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Data Analytics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 306
+     "indicative_closing_rank": 306,
+     "career_id": null
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 849
+     "indicative_closing_rank": 849,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Computational Engineering and Mechanics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1309
+     "indicative_closing_rank": 1309,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1441
+     "indicative_closing_rank": 1441,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2468
+     "indicative_closing_rank": 2468,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Aerospace Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 2808
+     "indicative_closing_rank": 2808,
+     "career_id": "aerospace-engineering"
     },
     {
      "branch": "Aerospace Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3211
+     "indicative_closing_rank": 3211,
+     "career_id": "aerospace-engineering"
     },
     {
      "branch": "Engineering Design",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 3380
+     "indicative_closing_rank": 3380,
+     "career_id": null
     },
     {
      "branch": "Physics",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 3804
+     "indicative_closing_rank": 3804,
+     "career_id": "physics"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4116
+     "indicative_closing_rank": 4116,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Instrumentation and Biomedical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4366
+     "indicative_closing_rank": 4366,
+     "career_id": "biomedical-engineering"
     },
     {
      "branch": "Biological Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5261
+     "indicative_closing_rank": 5261,
+     "career_id": "biological-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5499
+     "indicative_closing_rank": 5499,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6112
+     "indicative_closing_rank": 6112,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Naval Architecture and Ocean Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7433
+     "indicative_closing_rank": 7433,
+     "career_id": "marine-ocean-engineering"
     },
     {
      "branch": "Biological Science",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 10290
+     "indicative_closing_rank": 10290,
+     "career_id": "biological-science-and-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -251,133 +268,155 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 126
+     "indicative_closing_rank": 126,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 186
+     "indicative_closing_rank": 186,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 323
+     "indicative_closing_rank": 323,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 355
+     "indicative_closing_rank": 355,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 605
+     "indicative_closing_rank": 605,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering (Power and Automation)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 823
+     "indicative_closing_rank": 823,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Engineering and Computational Mechanics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1103
+     "indicative_closing_rank": 1103,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Abu Dhabi Campus - Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1761
+     "indicative_closing_rank": 1761,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1862
+     "indicative_closing_rank": 1862,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2548
+     "indicative_closing_rank": 2548,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2565
+     "indicative_closing_rank": 2565,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Energy Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2668
+     "indicative_closing_rank": 2668,
+     "career_id": "energy-engineering"
     },
     {
      "branch": "Production and Industrial Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3223
+     "indicative_closing_rank": 3223,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 3454
+     "indicative_closing_rank": 3454,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3736
+     "indicative_closing_rank": 3736,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4302
+     "indicative_closing_rank": 4302,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Biotechnology and Biochemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4999
+     "indicative_closing_rank": 4999,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Abu Dhabi Campus - Energy Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5590
+     "indicative_closing_rank": 5590,
+     "career_id": "energy-engineering"
     },
     {
      "branch": "Abu Dhabi Campus - Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5712
+     "indicative_closing_rank": 5712,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Textile Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5733
+     "indicative_closing_rank": 5733,
+     "career_id": "textile-engineering"
     },
     {
      "branch": "Chemistry",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 8528
+     "indicative_closing_rank": 8528,
+     "career_id": "chemistry"
     },
     {
      "branch": "Design",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12217
+     "indicative_closing_rank": 12217,
+     "career_id": "design"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -496,97 +535,113 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 66
+     "indicative_closing_rank": 66,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 433
+     "indicative_closing_rank": 433,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 841
+     "indicative_closing_rank": 841,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "BS in Mathematics",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 1067
+     "indicative_closing_rank": 1067,
+     "career_id": "mathematics"
     },
     {
      "branch": "Industrial Engineering and Operations Research",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1273
+     "indicative_closing_rank": 1273,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1539
+     "indicative_closing_rank": 1539,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1834
+     "indicative_closing_rank": 1834,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Aerospace Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2361
+     "indicative_closing_rank": 2361,
+     "career_id": "aerospace-engineering"
     },
     {
      "branch": "Economics",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 2372
+     "indicative_closing_rank": 2372,
+     "career_id": "economics"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2464
+     "indicative_closing_rank": 2464,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Energy Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2584
+     "indicative_closing_rank": 2584,
+     "career_id": "energy-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4250
+     "indicative_closing_rank": 4250,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Metallurgical Engineering and Materials Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4345
+     "indicative_closing_rank": 4345,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Environmental Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4777
+     "indicative_closing_rank": 4777,
+     "career_id": "environmental-engineering"
     },
     {
      "branch": "Chemistry",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 7228
+     "indicative_closing_rank": 7228,
+     "career_id": "chemistry"
     },
     {
      "branch": "Applied Geophysics",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 8343
+     "indicative_closing_rank": 8343,
+     "career_id": "physics"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -704,85 +759,99 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 271
+     "indicative_closing_rank": 271,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1146
+     "indicative_closing_rank": 1146,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mathematics and Scientific Computing",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 1179
+     "indicative_closing_rank": 1179,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Statistics and Data Science",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 1270
+     "indicative_closing_rank": 1270,
+     "career_id": null
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2771
+     "indicative_closing_rank": 2771,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Economics",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 3310
+     "indicative_closing_rank": 3310,
+     "career_id": "economics"
     },
     {
      "branch": "Aerospace Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3805
+     "indicative_closing_rank": 3805,
+     "career_id": "aerospace-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4280
+     "indicative_closing_rank": 4280,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Physics",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 5691
+     "indicative_closing_rank": 5691,
+     "career_id": "physics"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6161
+     "indicative_closing_rank": 6161,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Materials Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6337
+     "indicative_closing_rank": 6337,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Biological Sciences and Bioengineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7105
+     "indicative_closing_rank": 7105,
+     "career_id": "biological-engineering"
     },
     {
      "branch": "Earth Sciences",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 10108
+     "indicative_closing_rank": 10108,
+     "career_id": "earth-science-and-engineering"
     },
     {
      "branch": "Chemistry",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 10482
+     "indicative_closing_rank": 10482,
+     "career_id": "chemistry"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -902,139 +971,162 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 466
+     "indicative_closing_rank": 466,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 953
+     "indicative_closing_rank": 953,
+     "career_id": null
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 1336
+     "indicative_closing_rank": 1336,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Electrical Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1485
+     "indicative_closing_rank": 1485,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1985
+     "indicative_closing_rank": 1985,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Instrumentation Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2741
+     "indicative_closing_rank": 2741,
+     "career_id": "instrumentation-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4016
+     "indicative_closing_rank": 4016,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Industrial and Systems Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4329
+     "indicative_closing_rank": 4329,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Aerospace Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4872
+     "indicative_closing_rank": 4872,
+     "career_id": "aerospace-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5222
+     "indicative_closing_rank": 5222,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Economics",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 6063
+     "indicative_closing_rank": 6063,
+     "career_id": "economics"
     },
     {
      "branch": "Manufacturing Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6547
+     "indicative_closing_rank": 6547,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7708
+     "indicative_closing_rank": 7708,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7774
+     "indicative_closing_rank": 7774,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Biotechnology and Biochemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9224
+     "indicative_closing_rank": 9224,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Ocean Engineering and Naval Architecture",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10074
+     "indicative_closing_rank": 10074,
+     "career_id": "marine-ocean-engineering"
     },
     {
      "branch": "Mining Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10765
+     "indicative_closing_rank": 10765,
+     "career_id": "mining-engineering"
     },
     {
      "branch": "Physics",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 10939
+     "indicative_closing_rank": 10939,
+     "career_id": "physics"
     },
     {
      "branch": "Agricultural and Food Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11111
+     "indicative_closing_rank": 11111,
+     "career_id": "agricultural-engineering"
     },
     {
      "branch": "Chemistry",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 12321
+     "indicative_closing_rank": 12321,
+     "career_id": "chemistry"
     },
     {
      "branch": "Exploration Geophysics",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 12443
+     "indicative_closing_rank": 12443,
+     "career_id": "physics"
     },
     {
      "branch": "Applied Geology",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 13685
+     "indicative_closing_rank": 13685,
+     "career_id": "geology-geophysics-geological-technology"
     },
     {
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 19141
+     "indicative_closing_rank": 19141,
+     "career_id": "architecture"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -1155,115 +1247,134 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 592
+     "indicative_closing_rank": 592,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Data Science and Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 845
+     "indicative_closing_rank": 845,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1486
+     "indicative_closing_rank": 1486,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mathematics & Computing",
      "years": 5,
      "degree": "Bachelor of Science and Master of Science (Dual Degree)",
-     "indicative_closing_rank": 1513
+     "indicative_closing_rank": 1513,
+     "career_id": null
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2091
+     "indicative_closing_rank": 2091,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3897
+     "indicative_closing_rank": 3897,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4544
+     "indicative_closing_rank": 4544,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Energy Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4761
+     "indicative_closing_rank": 4761,
+     "career_id": "energy-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4816
+     "indicative_closing_rank": 4816,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Production and Industrial Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5820
+     "indicative_closing_rank": 5820,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Economics",
      "years": 5,
      "degree": "Bachelor of Science and Master of Science (Dual Degree)",
-     "indicative_closing_rank": 5938
+     "indicative_closing_rank": 5938,
+     "career_id": "economics"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6870
+     "indicative_closing_rank": 6870,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7341
+     "indicative_closing_rank": 7341,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Biosciences and Bioengineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8159
+     "indicative_closing_rank": 8159,
+     "career_id": "biological-engineering"
     },
     {
      "branch": "Geophysical Technology",
      "years": 5,
      "degree": "Integrated Master of Technology",
-     "indicative_closing_rank": 8870
+     "indicative_closing_rank": 8870,
+     "career_id": "geology-geophysics-geological-technology"
     },
     {
      "branch": "Geological Technology",
      "years": 5,
      "degree": "Integrated Master of Technology",
-     "indicative_closing_rank": 10016
+     "indicative_closing_rank": 10016,
+     "career_id": "geology-geophysics-geological-technology"
     },
     {
      "branch": "Physics",
      "years": 5,
      "degree": "Bachelor of Science and Master of Science (Dual Degree)",
-     "indicative_closing_rank": 10171
+     "indicative_closing_rank": 10171,
+     "career_id": "physics"
     },
     {
      "branch": "Chemical Sciences",
      "years": 5,
      "degree": "Bachelor of Science and Master of Science (Dual Degree)",
-     "indicative_closing_rank": 11130
+     "indicative_closing_rank": 11130,
+     "career_id": null
     },
     {
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 17665
+     "indicative_closing_rank": 17665,
+     "career_id": "architecture"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -1379,91 +1490,106 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 673
+     "indicative_closing_rank": 673,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 861
+     "indicative_closing_rank": 861,
+     "career_id": null
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1015
+     "indicative_closing_rank": 1015,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Computational Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1866
+     "indicative_closing_rank": 1866,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electrical Engineering (IC Design and Technology)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1895
+     "indicative_closing_rank": 1895,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1900
+     "indicative_closing_rank": 1900,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Engineering Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3272
+     "indicative_closing_rank": 3272,
+     "career_id": "engineering-science"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4443
+     "indicative_closing_rank": 4443,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4686
+     "indicative_closing_rank": 4686,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5756
+     "indicative_closing_rank": 5756,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Materials Science and Metallurgical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7604
+     "indicative_closing_rank": 7604,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Biomedical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8376
+     "indicative_closing_rank": 8376,
+     "career_id": "biomedical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8698
+     "indicative_closing_rank": 8698,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Biotechnology and Bioinformatics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9378
+     "indicative_closing_rank": 9378,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Industrial Chemistry",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10043
+     "indicative_closing_rank": 10043,
+     "career_id": "industrial-chemistry"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -1579,73 +1705,85 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 792
+     "indicative_closing_rank": 792,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Data Science and Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1078
+     "indicative_closing_rank": 1078,
+     "career_id": null
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1276
+     "indicative_closing_rank": 1276,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1829
+     "indicative_closing_rank": 1829,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2195
+     "indicative_closing_rank": 2195,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4892
+     "indicative_closing_rank": 4892,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6053
+     "indicative_closing_rank": 6053,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Energy Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6610
+     "indicative_closing_rank": 6610,
+     "career_id": "energy-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7117
+     "indicative_closing_rank": 7117,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Chemical Science and Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7958
+     "indicative_closing_rank": 7958,
+     "career_id": "chemical-science-and-technology"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9021
+     "indicative_closing_rank": 9021,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Biosciences and Bioengineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10727
+     "indicative_closing_rank": 10727,
+     "career_id": "biological-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -1764,61 +1902,71 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 470
+     "indicative_closing_rank": 470,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4569
+     "indicative_closing_rank": 4569,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7076
+     "indicative_closing_rank": 7076,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9411
+     "indicative_closing_rank": 9411,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Instrumentation and Control Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 13501
+     "indicative_closing_rank": 13501,
+     "career_id": "instrumentation-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14978
+     "indicative_closing_rank": 14978,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 20393
+     "indicative_closing_rank": 20393,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Production Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 24160
+     "indicative_closing_rank": 24160,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 27118
+     "indicative_closing_rank": 27118,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 31593
+     "indicative_closing_rank": 31593,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -1936,103 +2084,120 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1489
+     "indicative_closing_rank": 1489,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1924
+     "indicative_closing_rank": 1924,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2635
+     "indicative_closing_rank": 2635,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3537
+     "indicative_closing_rank": 3537,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7286
+     "indicative_closing_rank": 7286,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8381
+     "indicative_closing_rank": 8381,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8441
+     "indicative_closing_rank": 8441,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10278
+     "indicative_closing_rank": 10278,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Materials Science and Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10851
+     "indicative_closing_rank": 10851,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Metallurgical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11398
+     "indicative_closing_rank": 11398,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Industrial Chemistry",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12721
+     "indicative_closing_rank": 12721,
+     "career_id": "industrial-chemistry"
     },
     {
      "branch": "Bioengineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12759
+     "indicative_closing_rank": 12759,
+     "career_id": "biomedical-engineering"
     },
     {
      "branch": "Ceramic Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 13064
+     "indicative_closing_rank": 13064,
+     "career_id": "ceramic-engineering"
     },
     {
      "branch": "Biochemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 13255
+     "indicative_closing_rank": 13255,
+     "career_id": "biochemical-engineering"
     },
     {
      "branch": "Mining Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14243
+     "indicative_closing_rank": 14243,
+     "career_id": "mining-engineering"
     },
     {
      "branch": "Pharmaceutical Engineering & Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14447
+     "indicative_closing_rank": 14447,
+     "career_id": "pharmaceutical-engineering"
     },
     {
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 20792
+     "indicative_closing_rank": 20792,
+     "career_id": "architecture"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -2148,55 +2313,64 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1775
+     "indicative_closing_rank": 1775,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2099
+     "indicative_closing_rank": 2099,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3723
+     "indicative_closing_rank": 3723,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Space Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7419
+     "indicative_closing_rank": 7419,
+     "career_id": "space-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7545
+     "indicative_closing_rank": 7545,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8299
+     "indicative_closing_rank": 8299,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8824
+     "indicative_closing_rank": 8824,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10641
+     "indicative_closing_rank": 10641,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Metallurgical Engineering and Materials Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11274
+     "indicative_closing_rank": 11274,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -2317,145 +2491,169 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 1621
+     "indicative_closing_rank": 1621,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7853
+     "indicative_closing_rank": 7853,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9099
+     "indicative_closing_rank": 9099,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11195
+     "indicative_closing_rank": 11195,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Instrumentation Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 13784
+     "indicative_closing_rank": 13784,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16250
+     "indicative_closing_rank": 16250,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 21488
+     "indicative_closing_rank": 21488,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 23539
+     "indicative_closing_rank": 23539,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 28368
+     "indicative_closing_rank": 28368,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Industrial Design",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 31363
+     "indicative_closing_rank": 31363,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 31600
+     "indicative_closing_rank": 31600,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Chemical Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 33511
+     "indicative_closing_rank": 33511,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Mining Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 35731
+     "indicative_closing_rank": 35731,
+     "career_id": "mining-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 39890
+     "indicative_closing_rank": 39890,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Mining Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 41212
+     "indicative_closing_rank": 41212,
+     "career_id": "mining-engineering"
     },
     {
      "branch": "Bio Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 42292
+     "indicative_closing_rank": 42292,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Ceramic Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 43332
+     "indicative_closing_rank": 43332,
+     "career_id": "ceramic-engineering"
     },
     {
      "branch": "Bio Medical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 45885
+     "indicative_closing_rank": 45885,
+     "career_id": "biomedical-engineering"
     },
     {
      "branch": "Food Process Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 48809
+     "indicative_closing_rank": 48809,
+     "career_id": "food-engineering"
     },
     {
      "branch": "Ceramic Engineering and M.Tech Industrial Ceramic",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 50899
+     "indicative_closing_rank": 50899,
+     "career_id": null
     },
     {
      "branch": "Mathematics",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 52270
+     "indicative_closing_rank": 52270,
+     "career_id": "mathematics"
     },
     {
      "branch": "Physics",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 53337
+     "indicative_closing_rank": 53337,
+     "career_id": "physics"
     },
     {
      "branch": "Chemistry",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 60683
+     "indicative_closing_rank": 60683,
+     "career_id": "chemistry"
     },
     {
      "branch": "Life Science",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 81559
+     "indicative_closing_rank": 81559,
+     "career_id": "life-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -2575,109 +2773,127 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3585
+     "indicative_closing_rank": 3585,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4335
+     "indicative_closing_rank": 4335,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5839
+     "indicative_closing_rank": 5839,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7603
+     "indicative_closing_rank": 7603,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10273
+     "indicative_closing_rank": 10273,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11711
+     "indicative_closing_rank": 11711,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11980
+     "indicative_closing_rank": 11980,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Petroleum Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12709
+     "indicative_closing_rank": 12709,
+     "career_id": "petroleum-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 13778
+     "indicative_closing_rank": 13778,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Mineral and Metallurgical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14875
+     "indicative_closing_rank": 14875,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Mining Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15455
+     "indicative_closing_rank": 15455,
+     "career_id": "mining-engineering"
     },
     {
      "branch": "Mining Machinery Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16579
+     "indicative_closing_rank": 16579,
+     "career_id": "mining-engineering"
     },
     {
      "branch": "Environmental Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16752
+     "indicative_closing_rank": 16752,
+     "career_id": "environmental-engineering"
     },
     {
      "branch": "B.Tech Mining Engineering and MBA in Logistic and Supply Chain Management (IIM Mumbai)",
      "years": 5,
      "degree": "Integrated B. Tech. and MBA",
-     "indicative_closing_rank": 16770
+     "indicative_closing_rank": 16770,
+     "career_id": "mining-engineering"
     },
     {
      "branch": "Applied Geophysics",
      "years": 5,
      "degree": "Integrated Master of Technology",
-     "indicative_closing_rank": 17507
+     "indicative_closing_rank": 17507,
+     "career_id": "physics"
     },
     {
      "branch": "Applied Geology",
      "years": 5,
      "degree": "Integrated Master of Technology",
-     "indicative_closing_rank": 17892
+     "indicative_closing_rank": 17892,
+     "career_id": "geology-geophysics-geological-technology"
     },
     {
      "branch": "Chemical Science",
      "years": 5,
      "degree": "Integrated Bachelor of Science-Master of Science",
-     "indicative_closing_rank": 18334
+     "indicative_closing_rank": 18334,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Physical Science",
      "years": 5,
      "degree": "Integrated Bachelor of Science-Master of Science",
-     "indicative_closing_rank": 18368
+     "indicative_closing_rank": 18368,
+     "career_id": "physics"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -2794,67 +3010,78 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2800
+     "indicative_closing_rank": 2800,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3579
+     "indicative_closing_rank": 3579,
+     "career_id": null
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4086
+     "indicative_closing_rank": 4086,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computational and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4805
+     "indicative_closing_rank": 4805,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5573
+     "indicative_closing_rank": 5573,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7493
+     "indicative_closing_rank": 7493,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12126
+     "indicative_closing_rank": 12126,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 18581
+     "indicative_closing_rank": 18581,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 24264
+     "indicative_closing_rank": 24264,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 28252
+     "indicative_closing_rank": 28252,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Mining Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 39455
+     "indicative_closing_rank": 39455,
+     "career_id": "mining-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -2976,193 +3203,225 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3377
+     "indicative_closing_rank": 3377,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "B.Tech (Computer Science and Engineering) - MBA in Digital Business Management (IIM Bodh Gaya)",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 4297
+     "indicative_closing_rank": 4297,
+     "career_id": null
     },
     {
      "branch": "Artificial Intelligence and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4312
+     "indicative_closing_rank": 4312,
+     "career_id": null
     },
     {
      "branch": "B. Tech. (CSE) and M.Tech in CSE",
      "years": 5,
      "degree": "B.Tech. + M.Tech./MS (Dual Degree)",
-     "indicative_closing_rank": 4323
+     "indicative_closing_rank": 4323,
+     "career_id": null
     },
     {
      "branch": "B.Tech (Artificial Intelligence and Data Science) - MBA in Digital Business Management (IIM Bodh Gaya)",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 4679
+     "indicative_closing_rank": 4679,
+     "career_id": null
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4851
+     "indicative_closing_rank": 4851,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "B.Tech (Mathematics and Computing) - MBA in Digital Business Management (IIM Bodh Gaya)",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 5192
+     "indicative_closing_rank": 5192,
+     "career_id": null
     },
     {
      "branch": "B. Tech. (Mathematics & Computing) M. Tech. in (Mathematics & Computing)",
      "years": 5,
      "degree": "B.Tech. + M.Tech./MS (Dual Degree)",
-     "indicative_closing_rank": 5266
+     "indicative_closing_rank": 5266,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6167
+     "indicative_closing_rank": 6167,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7502
+     "indicative_closing_rank": 7502,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "B. Tech. (ECE) -M. Tech. in VLSI",
      "years": 5,
      "degree": "B.Tech. + M.Tech./MS (Dual Degree)",
-     "indicative_closing_rank": 7742
+     "indicative_closing_rank": 7742,
+     "career_id": null
     },
     {
      "branch": "B.Tech. in Electronics and Communication Engineering and M.Tech. in Communication Systems",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 7786
+     "indicative_closing_rank": 7786,
+     "career_id": null
     },
     {
      "branch": "B. Tech. (EEE)-M. Tech. in (Power &. Control)",
      "years": 5,
      "degree": "B.Tech. + M.Tech./MS (Dual Degree)",
-     "indicative_closing_rank": 8283
+     "indicative_closing_rank": 8283,
+     "career_id": null
     },
     {
      "branch": "B.Tech (Electrical and Electronics Engineering) - MBA (IIM Bodh Gaya)",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 8351
+     "indicative_closing_rank": 8351,
+     "career_id": null
     },
     {
      "branch": "B.Tech (Electronics and Communication Engineering) - MBA in Hospital and Healthcare Management (IIM Bodh Gaya)",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 8739
+     "indicative_closing_rank": 8739,
+     "career_id": null
     },
     {
      "branch": "B.Tech (Mechanical Engineering) - MBA (IIM Mumbai)",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 9708
+     "indicative_closing_rank": 9708,
+     "career_id": null
     },
     {
      "branch": "B. Tech. (ME) - M. Tech. in Mechatronics",
      "years": 5,
      "degree": "B.Tech. + M.Tech./MS (Dual Degree)",
-     "indicative_closing_rank": 10153
+     "indicative_closing_rank": 10153,
+     "career_id": null
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11758
+     "indicative_closing_rank": 11758,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12986
+     "indicative_closing_rank": 12986,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "B.Tech (Engineering Physics) - MBA (IIM Bodh Gaya)",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 12995
+     "indicative_closing_rank": 12995,
+     "career_id": null
     },
     {
      "branch": "BS in Economics with MBA (IIM Bodh Gaya)",
      "years": 5,
      "degree": "Bachelor of Science and MBA (Dual Degree)",
-     "indicative_closing_rank": 13325
+     "indicative_closing_rank": 13325,
+     "career_id": null
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 13715
+     "indicative_closing_rank": 13715,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Economics",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 13720
+     "indicative_closing_rank": 13720,
+     "career_id": "economics"
     },
     {
      "branch": "B.Tech (Chemical Engineering) - MBA in Hospital and Health Care Management (IIM Bodh Gaya)",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 15010
+     "indicative_closing_rank": 15010,
+     "career_id": null
     },
     {
      "branch": "B. Tech in CE. - M. Tech. in Structural Engineering",
      "years": 5,
      "degree": "B.Tech. + M.Tech./MS (Dual Degree)",
-     "indicative_closing_rank": 15381
+     "indicative_closing_rank": 15381,
+     "career_id": null
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15400
+     "indicative_closing_rank": 15400,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Chemical Science and Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15406
+     "indicative_closing_rank": 15406,
+     "career_id": "chemical-science-and-technology"
     },
     {
      "branch": "B.Tech (Civil Engineering) - MBA (IIM Bodh Gaya)",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 15570
+     "indicative_closing_rank": 15570,
+     "career_id": null
     },
     {
      "branch": "B.Tech (Metallurgical and Materials Engineering) - MBA (IIM Bodh Gaya)",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 16042
+     "indicative_closing_rank": 16042,
+     "career_id": null
     },
     {
      "branch": "B.Tech (Chemical Science and Technology) - MBA in Hospital and Health Care Management (IIM Bodh Gaya)",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 16163
+     "indicative_closing_rank": 16163,
+     "career_id": null
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16510
+     "indicative_closing_rank": 16510,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "B. Tech in CE. - M. Tech. in Geotechnical Engineering",
      "years": 5,
      "degree": "B.Tech. + M.Tech./MS (Dual Degree)",
-     "indicative_closing_rank": 16815
+     "indicative_closing_rank": 16815,
+     "career_id": null
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -3281,73 +3540,85 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 289
+     "indicative_closing_rank": 289,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8428
+     "indicative_closing_rank": 8428,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12693
+     "indicative_closing_rank": 12693,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16349
+     "indicative_closing_rank": 16349,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 21336
+     "indicative_closing_rank": 21336,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 21952
+     "indicative_closing_rank": 21952,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 26665
+     "indicative_closing_rank": 26665,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Energy Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 29616
+     "indicative_closing_rank": 29616,
+     "career_id": "energy-engineering"
     },
     {
      "branch": "Production Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 36474
+     "indicative_closing_rank": 36474,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Materials Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 38319
+     "indicative_closing_rank": 38319,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Bio Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 41439
+     "indicative_closing_rank": 41439,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 41708
+     "indicative_closing_rank": 41708,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -3463,49 +3734,57 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2020
+     "indicative_closing_rank": 2020,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2236
+     "indicative_closing_rank": 2236,
+     "career_id": null
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3931
+     "indicative_closing_rank": 3931,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Integrated Circuit Design & Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4652
+     "indicative_closing_rank": 4652,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6904
+     "indicative_closing_rank": 6904,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9276
+     "indicative_closing_rank": 9276,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10796
+     "indicative_closing_rank": 10796,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11066
+     "indicative_closing_rank": 11066,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -3623,73 +3902,85 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3123
+     "indicative_closing_rank": 3123,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Data Science and Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3928
+     "indicative_closing_rank": 3928,
+     "career_id": null
     },
     {
      "branch": "B.Tech in Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4285
+     "indicative_closing_rank": 4285,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "B.Tech in Microelectronics & VLSI",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6166
+     "indicative_closing_rank": 6166,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7590
+     "indicative_closing_rank": 7590,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10267
+     "indicative_closing_rank": 10267,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "B.Tech in General Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11034
+     "indicative_closing_rank": 11034,
+     "career_id": "general-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12110
+     "indicative_closing_rank": 12110,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14274
+     "indicative_closing_rank": 14274,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "B.Tech in Materials Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14368
+     "indicative_closing_rank": 14368,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Bio Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14879
+     "indicative_closing_rank": 14879,
+     "career_id": "biological-engineering"
     },
     {
      "branch": "BS in Chemical Sciences",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 17491
+     "indicative_closing_rank": 17491,
+     "career_id": "chemical-science-and-technology"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -3807,67 +4098,78 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2918
+     "indicative_closing_rank": 2918,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4212
+     "indicative_closing_rank": 4212,
+     "career_id": null
     },
     {
      "branch": "Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6228
+     "indicative_closing_rank": 6228,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6824
+     "indicative_closing_rank": 6824,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9569
+     "indicative_closing_rank": 9569,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11626
+     "indicative_closing_rank": 11626,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil and Infrastructure Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14301
+     "indicative_closing_rank": 14301,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15034
+     "indicative_closing_rank": 15034,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Physics with Specialization",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 15185
+     "indicative_closing_rank": 15185,
+     "career_id": "physics"
     },
     {
      "branch": "Bio Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15278
+     "indicative_closing_rank": 15278,
+     "career_id": "biological-engineering"
     },
     {
      "branch": "Chemistry with Specialization",
      "years": 4,
      "degree": "Bachelor of Science",
-     "indicative_closing_rank": 18310
+     "indicative_closing_rank": 18310,
+     "career_id": "chemistry"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -3986,97 +4288,113 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3530
+     "indicative_closing_rank": 3530,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering ( Artificial Intelligence & Data Science)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4316
+     "indicative_closing_rank": 4316,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5438
+     "indicative_closing_rank": 5438,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6446
+     "indicative_closing_rank": 6446,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering (VLSI Design and Technology)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6831
+     "indicative_closing_rank": 6831,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11204
+     "indicative_closing_rank": 11204,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 17643
+     "indicative_closing_rank": 17643,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 24880
+     "indicative_closing_rank": 24880,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 31919
+     "indicative_closing_rank": 31919,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 32174
+     "indicative_closing_rank": 32174,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 36742
+     "indicative_closing_rank": 36742,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Physics",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 37387
+     "indicative_closing_rank": 37387,
+     "career_id": "physics"
     },
     {
      "branch": "Mathematics",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 37824
+     "indicative_closing_rank": 37824,
+     "career_id": "mathematics"
     },
     {
      "branch": "Bio Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 41671
+     "indicative_closing_rank": 41671,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Chemistry",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 42007
+     "indicative_closing_rank": 42007,
+     "career_id": "chemistry"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 45837
+     "indicative_closing_rank": 45837,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -4192,67 +4510,78 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 2512
+     "indicative_closing_rank": 2512,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Data Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3500
+     "indicative_closing_rank": 3500,
+     "career_id": null
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 3954
+     "indicative_closing_rank": 3954,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electrical Engineering (Integrated Circuit Design and Technology)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5527
+     "indicative_closing_rank": 5527,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6311
+     "indicative_closing_rank": 6311,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9115
+     "indicative_closing_rank": 9115,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9576
+     "indicative_closing_rank": 9576,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10655
+     "indicative_closing_rank": 10655,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12488
+     "indicative_closing_rank": 12488,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 13777
+     "indicative_closing_rank": 13777,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Digital Agriculture",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14480
+     "indicative_closing_rank": 14480,
+     "career_id": "agricultural-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -4368,49 +4697,57 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4162
+     "indicative_closing_rank": 4162,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 4708
+     "indicative_closing_rank": 4708,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5885
+     "indicative_closing_rank": 5885,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8165
+     "indicative_closing_rank": 8165,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11678
+     "indicative_closing_rank": 11678,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12466
+     "indicative_closing_rank": 12466,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16156
+     "indicative_closing_rank": 16156,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16268
+     "indicative_closing_rank": 16268,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -4529,55 +4866,64 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 1983
+     "indicative_closing_rank": 1983,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6013
+     "indicative_closing_rank": 6013,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Data Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6491
+     "indicative_closing_rank": 6491,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10539
+     "indicative_closing_rank": 10539,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14665
+     "indicative_closing_rank": 14665,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 20213
+     "indicative_closing_rank": 20213,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 26449
+     "indicative_closing_rank": 26449,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 35746
+     "indicative_closing_rank": 35746,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 38003
+     "indicative_closing_rank": 38003,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -4696,55 +5042,64 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 715
+     "indicative_closing_rank": 715,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7203
+     "indicative_closing_rank": 7203,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11176
+     "indicative_closing_rank": 11176,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15641
+     "indicative_closing_rank": 15641,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 21761
+     "indicative_closing_rank": 21761,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 31613
+     "indicative_closing_rank": 31613,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 40998
+     "indicative_closing_rank": 40998,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 44638
+     "indicative_closing_rank": 44638,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Mining Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 49473
+     "indicative_closing_rank": 49473,
+     "career_id": "mining-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -4863,73 +5218,85 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11587
+     "indicative_closing_rank": 11587,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "B.Tech in Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14160
+     "indicative_closing_rank": 14160,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16672
+     "indicative_closing_rank": 16672,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 21358
+     "indicative_closing_rank": 21358,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 33709
+     "indicative_closing_rank": 33709,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 37802
+     "indicative_closing_rank": 37802,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 39414
+     "indicative_closing_rank": 39414,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 45449
+     "indicative_closing_rank": 45449,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 45938
+     "indicative_closing_rank": 45938,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Bio Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 52812
+     "indicative_closing_rank": 52812,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Biotechnology",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 52931
+     "indicative_closing_rank": 52931,
+     "career_id": null
     },
     {
      "branch": "Chemistry",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 58659
+     "indicative_closing_rank": 58659,
+     "career_id": "chemistry"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -5046,37 +5413,43 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 23366
+     "indicative_closing_rank": 23366,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 40328
+     "indicative_closing_rank": 40328,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Instrumentation Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 50066
+     "indicative_closing_rank": 50066,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 58422
+     "indicative_closing_rank": 58422,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 68356
+     "indicative_closing_rank": 68356,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 80869
+     "indicative_closing_rank": 80869,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -5196,85 +5569,99 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 3690
+     "indicative_closing_rank": 3690,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 32592
+     "indicative_closing_rank": 32592,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Machine Learning",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 37238
+     "indicative_closing_rank": 37238,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 48312
+     "indicative_closing_rank": 48312,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 54382
+     "indicative_closing_rank": 54382,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 69698
+     "indicative_closing_rank": 69698,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 73499
+     "indicative_closing_rank": 73499,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 91841
+     "indicative_closing_rank": 91841,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 92424
+     "indicative_closing_rank": 92424,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Quantitative Economics & Data Science",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 98345
+     "indicative_closing_rank": 98345,
+     "career_id": "economics"
     },
     {
      "branch": "Bio Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 113717
+     "indicative_closing_rank": 113717,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Physics",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 121027
+     "indicative_closing_rank": 121027,
+     "career_id": "physics"
     },
     {
      "branch": "Production and Industrial Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 121470
+     "indicative_closing_rank": 121470,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Food Engineering and Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 122354
+     "indicative_closing_rank": 122354,
+     "career_id": "food-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -5394,109 +5781,127 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 4364
+     "indicative_closing_rank": 4364,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 17808
+     "indicative_closing_rank": 17808,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 21207
+     "indicative_closing_rank": 21207,
+     "career_id": null
     },
     {
      "branch": "Computer Science and Engineering with Specialization in Data Science",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 22789
+     "indicative_closing_rank": 22789,
+     "career_id": null
     },
     {
      "branch": "Computer Science and Engineering with Specialization in Cyber Security",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 23681
+     "indicative_closing_rank": 23681,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 25184
+     "indicative_closing_rank": 25184,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mathematics and Computing Technology",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 25200
+     "indicative_closing_rank": 25200,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering with Specialization in Microelectronics and VLSI System Design",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 29291
+     "indicative_closing_rank": 29291,
+     "career_id": null
     },
     {
      "branch": "Electronics Engineering (VLSI Design and Technology)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 30551
+     "indicative_closing_rank": 30551,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 31816
+     "indicative_closing_rank": 31816,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechatronics and Automation Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 33461
+     "indicative_closing_rank": 33461,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Electrical Engineering with Specialization In Power System Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 35951
+     "indicative_closing_rank": 35951,
+     "career_id": null
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 38896
+     "indicative_closing_rank": 38896,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Mechanical Engineering with Specialization in Manufacturing and Industrial Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 46166
+     "indicative_closing_rank": 46166,
+     "career_id": null
     },
     {
      "branch": "Civil Engineering with Specialization in Construction Technology and Management",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 48231
+     "indicative_closing_rank": 48231,
+     "career_id": null
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 48513
+     "indicative_closing_rank": 48513,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Chemical Technology",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 54920
+     "indicative_closing_rank": 54920,
+     "career_id": null
     },
     {
      "branch": "Material Science and Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 55890
+     "indicative_closing_rank": 55890,
+     "career_id": null
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -5615,61 +6020,71 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 985
+     "indicative_closing_rank": 985,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16765
+     "indicative_closing_rank": 16765,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Telecommunication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 23027
+     "indicative_closing_rank": 23027,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 23059
+     "indicative_closing_rank": 23059,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 30994
+     "indicative_closing_rank": 30994,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Aerospace Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 37258
+     "indicative_closing_rank": 37258,
+     "career_id": "aerospace-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 39236
+     "indicative_closing_rank": 39236,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Metallurgy and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 53570
+     "indicative_closing_rank": 53570,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 53728
+     "indicative_closing_rank": 53728,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Mining Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 58114
+     "indicative_closing_rank": 58114,
+     "career_id": "mining-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -5786,85 +6201,99 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16325
+     "indicative_closing_rank": 16325,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Data Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 20283
+     "indicative_closing_rank": 20283,
+     "career_id": null
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 23198
+     "indicative_closing_rank": 23198,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 23297
+     "indicative_closing_rank": 23297,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 26658
+     "indicative_closing_rank": 26658,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and VLSI Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 27873
+     "indicative_closing_rank": 27873,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 29947
+     "indicative_closing_rank": 29947,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Instrumentation and Control Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 45047
+     "indicative_closing_rank": 45047,
+     "career_id": "instrumentation-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 46722
+     "indicative_closing_rank": 46722,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 57036
+     "indicative_closing_rank": 57036,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 58952
+     "indicative_closing_rank": 58952,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Industrial and Production Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 68146
+     "indicative_closing_rank": 68146,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Bio Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 79511
+     "indicative_closing_rank": 79511,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Textile Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 89077
+     "indicative_closing_rank": 89077,
+     "career_id": "textile-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -5980,49 +6409,57 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6651
+     "indicative_closing_rank": 6651,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8559
+     "indicative_closing_rank": 8559,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11399
+     "indicative_closing_rank": 11399,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14453
+     "indicative_closing_rank": 14453,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15917
+     "indicative_closing_rank": 15917,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16284
+     "indicative_closing_rank": 16284,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 17263
+     "indicative_closing_rank": 17263,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 18156
+     "indicative_closing_rank": 18156,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -6123,37 +6560,43 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 5034
+     "indicative_closing_rank": 5034,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9468
+     "indicative_closing_rank": 9468,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12143
+     "indicative_closing_rank": 12143,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12915
+     "indicative_closing_rank": 12915,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15636
+     "indicative_closing_rank": 15636,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16548
+     "indicative_closing_rank": 16548,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -6260,61 +6703,71 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6562
+     "indicative_closing_rank": 6562,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9577
+     "indicative_closing_rank": 9577,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11665
+     "indicative_closing_rank": 11665,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Engineering and Computational Mechanics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12759
+     "indicative_closing_rank": 12759,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 21070
+     "indicative_closing_rank": 21070,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 22469
+     "indicative_closing_rank": 22469,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 31589
+     "indicative_closing_rank": 31589,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Production and Industrial Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 35132
+     "indicative_closing_rank": 35132,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 38442
+     "indicative_closing_rank": 38442,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Bio Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 39400
+     "indicative_closing_rank": 39400,
+     "career_id": "biotechnology"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -6430,31 +6883,36 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6454
+     "indicative_closing_rank": 6454,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Data Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8640
+     "indicative_closing_rank": 8640,
+     "career_id": null
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10396
+     "indicative_closing_rank": 10396,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12606
+     "indicative_closing_rank": 12606,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16753
+     "indicative_closing_rank": 16753,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -6561,49 +7019,57 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10165
+     "indicative_closing_rank": 10165,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11212
+     "indicative_closing_rank": 11212,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15523
+     "indicative_closing_rank": 15523,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "VLSI Design and Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16548
+     "indicative_closing_rank": 16548,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Aerospace Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 21452
+     "indicative_closing_rank": 21452,
+     "career_id": "aerospace-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 21491
+     "indicative_closing_rank": 21491,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 28430
+     "indicative_closing_rank": 28430,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 36027
+     "indicative_closing_rank": 36027,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -6712,91 +7178,106 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8130
+     "indicative_closing_rank": 8130,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10331
+     "indicative_closing_rank": 10331,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12415
+     "indicative_closing_rank": 12415,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15005
+     "indicative_closing_rank": 15005,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Artificial Intelligence",
      "years": 5,
      "degree": "Integrated B. Tech. and M. Tech.",
-     "indicative_closing_rank": 16395
+     "indicative_closing_rank": 16395,
+     "career_id": null
     },
     {
      "branch": "Electronics and VLSI Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 17199
+     "indicative_closing_rank": 17199,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 23449
+     "indicative_closing_rank": 23449,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 34584
+     "indicative_closing_rank": 34584,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 42569
+     "indicative_closing_rank": 42569,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 45221
+     "indicative_closing_rank": 45221,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 50289
+     "indicative_closing_rank": 50289,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Industrial Chemistry",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 55833
+     "indicative_closing_rank": 55833,
+     "career_id": "industrial-chemistry"
     },
     {
      "branch": "Physics",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 65486
+     "indicative_closing_rank": 65486,
+     "career_id": "physics"
     },
     {
      "branch": "Mathematics",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 71752
+     "indicative_closing_rank": 71752,
+     "career_id": "mathematics"
     },
     {
      "branch": "Chemistry",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 81657
+     "indicative_closing_rank": 81657,
+     "career_id": "chemistry"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -6912,43 +7393,50 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7382
+     "indicative_closing_rank": 7382,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Data Science and Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7934
+     "indicative_closing_rank": 7934,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9668
+     "indicative_closing_rank": 9668,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11592
+     "indicative_closing_rank": 11592,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechatronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12254
+     "indicative_closing_rank": 12254,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14788
+     "indicative_closing_rank": 14788,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Materials Science and Metallurgical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 17478
+     "indicative_closing_rank": 17478,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -7051,49 +7539,57 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 220991
+     "indicative_closing_rank": 220991,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 238562
+     "indicative_closing_rank": 238562,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 306845
+     "indicative_closing_rank": 306845,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 315730
+     "indicative_closing_rank": 315730,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 334003
+     "indicative_closing_rank": 334003,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 340899
+     "indicative_closing_rank": 340899,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 372690
+     "indicative_closing_rank": 372690,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 467655
+     "indicative_closing_rank": 467655,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -7205,13 +7701,15 @@
      "branch": "Computer Science and Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 36294
+     "indicative_closing_rank": 36294,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Materials Engineering",
      "years": 5,
      "degree": "Integrated Master of Technology",
-     "indicative_closing_rank": 72228
+     "indicative_closing_rank": 72228,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -7298,55 +7796,64 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7208
+     "indicative_closing_rank": 7208,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8222
+     "indicative_closing_rank": 8222,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9476
+     "indicative_closing_rank": 9476,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11051
+     "indicative_closing_rank": 11051,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14852
+     "indicative_closing_rank": 14852,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15353
+     "indicative_closing_rank": 15353,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Chemical and Biochemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 16680
+     "indicative_closing_rank": 16680,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil and Infrastructure Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 17472
+     "indicative_closing_rank": 17472,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Interdisciplinary Sciences",
      "years": 5,
      "degree": "Bachelor of Science and Master of Science (Dual Degree)",
-     "indicative_closing_rank": 18979
+     "indicative_closing_rank": 18979,
+     "career_id": null
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -7444,91 +7951,106 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 64256
+     "indicative_closing_rank": 64256,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 66031
+     "indicative_closing_rank": 66031,
+     "career_id": null
     },
     {
      "branch": "Physics",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 70277
+     "indicative_closing_rank": 70277,
+     "career_id": "physics"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 70288
+     "indicative_closing_rank": 70288,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 71482
+     "indicative_closing_rank": 71482,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 81072
+     "indicative_closing_rank": 81072,
+     "career_id": "mathematics"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 81868
+     "indicative_closing_rank": 81868,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 90963
+     "indicative_closing_rank": 90963,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Chemistry",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 91170
+     "indicative_closing_rank": 91170,
+     "career_id": "chemistry"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 99763
+     "indicative_closing_rank": 99763,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 102094
+     "indicative_closing_rank": 102094,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 102905
+     "indicative_closing_rank": 102905,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 102957
+     "indicative_closing_rank": 102957,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Instrumentation and Control Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 103559
+     "indicative_closing_rank": 103559,
+     "career_id": "instrumentation-engineering"
     },
     {
      "branch": "Food Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 121270
+     "indicative_closing_rank": 121270,
+     "career_id": "food-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -7650,73 +8172,85 @@
      "branch": "Planning",
      "years": 4,
      "degree": "Bachelor of Planning",
-     "indicative_closing_rank": 2659
+     "indicative_closing_rank": 2659,
+     "career_id": "planning"
     },
     {
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 3688
+     "indicative_closing_rank": 3688,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11415
+     "indicative_closing_rank": 11415,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Data Science",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 16703
+     "indicative_closing_rank": 16703,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 18120
+     "indicative_closing_rank": 18120,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 24120
+     "indicative_closing_rank": 24120,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "B. Tech. and M. Tech. in Engineering and Computational Mechanics (Dual Degree)",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 30890
+     "indicative_closing_rank": 30890,
+     "career_id": null
     },
     {
      "branch": "Energy and Electrical Vehicle Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 32924
+     "indicative_closing_rank": 32924,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 34275
+     "indicative_closing_rank": 34275,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 40308
+     "indicative_closing_rank": 40308,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 46288
+     "indicative_closing_rank": 46288,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Materials Science and Metallurgical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 51350
+     "indicative_closing_rank": 51350,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -7836,85 +8370,99 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 75417
+     "indicative_closing_rank": 75417,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 105936
+     "indicative_closing_rank": 105936,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 127385
+     "indicative_closing_rank": 127385,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Instrumentation Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 147524
+     "indicative_closing_rank": 147524,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Computational Mathematics",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 167791
+     "indicative_closing_rank": 167791,
+     "career_id": null
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 204344
+     "indicative_closing_rank": 204344,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Mathematics & Computing",
      "years": 5,
      "degree": "Bachelor of Science and Master of Science (Dual Degree)",
-     "indicative_closing_rank": 234846
+     "indicative_closing_rank": 234846,
+     "career_id": null
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 237394
+     "indicative_closing_rank": 237394,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 256835
+     "indicative_closing_rank": 256835,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Production Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 308003
+     "indicative_closing_rank": 308003,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 311214
+     "indicative_closing_rank": 311214,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Biotechnology and Biochemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 320421
+     "indicative_closing_rank": 320421,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Physics",
      "years": 5,
      "degree": "Bachelor of Science and Master of Science (Dual Degree)",
-     "indicative_closing_rank": 343077
+     "indicative_closing_rank": 343077,
+     "career_id": "physics"
     },
     {
      "branch": "Chemistry",
      "years": 5,
      "degree": "Bachelor of Science and Master of Science (Dual Degree)",
-     "indicative_closing_rank": 346939
+     "indicative_closing_rank": 346939,
+     "career_id": "chemistry"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -8035,49 +8583,57 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11978
+     "indicative_closing_rank": 11978,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 17746
+     "indicative_closing_rank": 17746,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 22552
+     "indicative_closing_rank": 22552,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Engineering and Computational Mechanics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 26546
+     "indicative_closing_rank": 26546,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 33156
+     "indicative_closing_rank": 33156,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 48995
+     "indicative_closing_rank": 48995,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 49446
+     "indicative_closing_rank": 49446,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Production and Industrial Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 56066
+     "indicative_closing_rank": 56066,
+     "career_id": "industrial-manufacturing-production-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -8182,31 +8738,36 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 59949
+     "indicative_closing_rank": 59949,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 136427
+     "indicative_closing_rank": 136427,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 146012
+     "indicative_closing_rank": 146012,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 146176
+     "indicative_closing_rank": 146176,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 318381
+     "indicative_closing_rank": 318381,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -8326,121 +8887,141 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 2110
+     "indicative_closing_rank": 2110,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8484
+     "indicative_closing_rank": 8484,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 11456
+     "indicative_closing_rank": 11456,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12252
+     "indicative_closing_rank": 12252,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Machine Learning",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12346
+     "indicative_closing_rank": 12346,
+     "career_id": null
     },
     {
      "branch": "Artificial Intelligence and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 12578
+     "indicative_closing_rank": 12578,
+     "career_id": null
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15269
+     "indicative_closing_rank": 15269,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 15889
+     "indicative_closing_rank": 15889,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 16112
+     "indicative_closing_rank": 16112,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "ROBOTICS & AUTOMATION",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 20596
+     "indicative_closing_rank": 20596,
+     "career_id": "robotics-engineering"
     },
     {
      "branch": "Microelectronics & VLSI Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 22646
+     "indicative_closing_rank": 22646,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 24102
+     "indicative_closing_rank": 24102,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Industrial Internet of Things",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 24176
+     "indicative_closing_rank": 24176,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 27197
+     "indicative_closing_rank": 27197,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 30173
+     "indicative_closing_rank": 30173,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 32679
+     "indicative_closing_rank": 32679,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 43064
+     "indicative_closing_rank": 43064,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Production and Industrial Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 44633
+     "indicative_closing_rank": 44633,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "SUSTAINABLE ENERGY TECHNOLOGIES",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 48578
+     "indicative_closing_rank": 48578,
+     "career_id": "energy-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 49120
+     "indicative_closing_rank": 49120,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -8559,73 +9140,85 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 3672
+     "indicative_closing_rank": 3672,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 21913
+     "indicative_closing_rank": 21913,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 30900
+     "indicative_closing_rank": 30900,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 40209
+     "indicative_closing_rank": 40209,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 51834
+     "indicative_closing_rank": 51834,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 59807
+     "indicative_closing_rank": 59807,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 66029
+     "indicative_closing_rank": 66029,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 73812
+     "indicative_closing_rank": 73812,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 85636
+     "indicative_closing_rank": 85636,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Mining Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 101941
+     "indicative_closing_rank": 101941,
+     "career_id": "mining-engineering"
     },
     {
      "branch": "Bio Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 108275
+     "indicative_closing_rank": 108275,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Bio Medical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 116282
+     "indicative_closing_rank": 116282,
+     "career_id": "biomedical-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -8741,19 +9334,22 @@
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6094
+     "indicative_closing_rank": 6094,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Information Technology-Business Informatics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6150
+     "indicative_closing_rank": 6150,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 8050
+     "indicative_closing_rank": 8050,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -8875,73 +9471,85 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 19702
+     "indicative_closing_rank": 19702,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science Engineering (Artificial Intelligence)",
      "years": 4,
      "degree": "B. Tech / B. Tech (Hons.)",
-     "indicative_closing_rank": 21260
+     "indicative_closing_rank": 21260,
+     "career_id": null
     },
     {
      "branch": "Computer Science Engineering (Data Science)",
      "years": 4,
      "degree": "B. Tech / B. Tech (Hons.)",
-     "indicative_closing_rank": 25310
+     "indicative_closing_rank": 25310,
+     "career_id": null
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 33277
+     "indicative_closing_rank": 33277,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 36774
+     "indicative_closing_rank": 36774,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics Engineering (VLSI Design and Technology)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 40631
+     "indicative_closing_rank": 40631,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 49806
+     "indicative_closing_rank": 49806,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Aerospace Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 55662
+     "indicative_closing_rank": 55662,
+     "career_id": "aerospace-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 67850
+     "indicative_closing_rank": 67850,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Production and Industrial Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 93234
+     "indicative_closing_rank": 93234,
+     "career_id": "industrial-manufacturing-production-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 106307
+     "indicative_closing_rank": 106307,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 117242
+     "indicative_closing_rank": 117242,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -9058,31 +9666,36 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 27338
+     "indicative_closing_rank": 27338,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 45337
+     "indicative_closing_rank": 45337,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 64851
+     "indicative_closing_rank": 64851,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 90522
+     "indicative_closing_rank": 90522,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 114549
+     "indicative_closing_rank": 114549,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -9198,31 +9811,36 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 215198
+     "indicative_closing_rank": 215198,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 278552
+     "indicative_closing_rank": 278552,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 346687
+     "indicative_closing_rank": 346687,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 352131
+     "indicative_closing_rank": 352131,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 529893
+     "indicative_closing_rank": 529893,
+     "career_id": "mechanical-mechatronics-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -9344,31 +9962,36 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9527
+     "indicative_closing_rank": 9527,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Scientific Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11710
+     "indicative_closing_rank": 11710,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Integrated B. Tech.(IT) and M. Tech (IT)",
      "years": 5,
      "degree": "Integrated B. Tech. and M. Tech.",
-     "indicative_closing_rank": 13473
+     "indicative_closing_rank": 13473,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Integrated B. Tech.(IT) and MBA",
      "years": 5,
      "degree": "Integrated B. Tech. and MBA",
-     "indicative_closing_rank": 15680
+     "indicative_closing_rank": 15680,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 17366
+     "indicative_closing_rank": 17366,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -9488,73 +10111,85 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 7861
+     "indicative_closing_rank": 7861,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 22394
+     "indicative_closing_rank": 22394,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 26321
+     "indicative_closing_rank": 26321,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 33284
+     "indicative_closing_rank": 33284,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 45099
+     "indicative_closing_rank": 45099,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 47782
+     "indicative_closing_rank": 47782,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 58330
+     "indicative_closing_rank": 58330,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 73871
+     "indicative_closing_rank": 73871,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 91171
+     "indicative_closing_rank": 91171,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 112244
+     "indicative_closing_rank": 112244,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 114049
+     "indicative_closing_rank": 114049,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Materials Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 117169
+     "indicative_closing_rank": 117169,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -9670,25 +10305,29 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 14787
+     "indicative_closing_rank": 14787,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 18809
+     "indicative_closing_rank": 18809,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 44435
+     "indicative_closing_rank": 44435,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Smart Manufacturing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 52669
+     "indicative_closing_rank": 52669,
+     "career_id": "industrial-manufacturing-production-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -9809,31 +10448,36 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 64692
+     "indicative_closing_rank": 64692,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 86567
+     "indicative_closing_rank": 86567,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 116492
+     "indicative_closing_rank": 116492,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 167788
+     "indicative_closing_rank": 167788,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 205593
+     "indicative_closing_rank": 205593,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -9946,55 +10590,64 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 1287
+     "indicative_closing_rank": 1287,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 69474
+     "indicative_closing_rank": 69474,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "B.Tech in Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 72314
+     "indicative_closing_rank": 72314,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Robotics and AI",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 74007
+     "indicative_closing_rank": 74007,
+     "career_id": null
     },
     {
      "branch": "Bio Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 83268
+     "indicative_closing_rank": 83268,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 87906
+     "indicative_closing_rank": 87906,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 94375
+     "indicative_closing_rank": 94375,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 94474
+     "indicative_closing_rank": 94474,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 102500
+     "indicative_closing_rank": 102500,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -10109,13 +10762,15 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 22739
+     "indicative_closing_rank": 22739,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 30554
+     "indicative_closing_rank": 30554,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -10222,79 +10877,92 @@
      "branch": "B.Tech. (Computer Science and Engineering) - MBA",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 58363
+     "indicative_closing_rank": 58363,
+     "career_id": null
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 64476
+     "indicative_closing_rank": 64476,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "B.Tech. (Food Engineering and Technology) - MBA",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 72557
+     "indicative_closing_rank": 72557,
+     "career_id": null
     },
     {
      "branch": "B.Tech. (Electronics and Communication Engineering) - MBA",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 72944
+     "indicative_closing_rank": 72944,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 75585
+     "indicative_closing_rank": 75585,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "B.Tech. (Mechanical Engineering) - MBA",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 78838
+     "indicative_closing_rank": 78838,
+     "career_id": null
     },
     {
      "branch": "B.Tech. (Elctrical Engineering) - MBA",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 83701
+     "indicative_closing_rank": 83701,
+     "career_id": null
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 86122
+     "indicative_closing_rank": 86122,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "B.Tech. (Civil Engineering) - MBA",
      "years": 5,
      "degree": "Bachelor of Technology and MBA (Dual Degree)",
-     "indicative_closing_rank": 87713
+     "indicative_closing_rank": 87713,
+     "career_id": null
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 91057
+     "indicative_closing_rank": 91057,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Bachelor of Design",
      "years": 4,
      "degree": "Bachelor of Design",
-     "indicative_closing_rank": 92713
+     "indicative_closing_rank": 92713,
+     "career_id": "design"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 104195
+     "indicative_closing_rank": 104195,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Food Engineering and Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 121531
+     "indicative_closing_rank": 121531,
+     "career_id": "food-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -10394,7 +11062,8 @@
      "branch": "Food Technology and Management",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 120222
+     "indicative_closing_rank": 120222,
+     "career_id": "food-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -10505,31 +11174,36 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 30851
+     "indicative_closing_rank": 30851,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 43978
+     "indicative_closing_rank": 43978,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 48247
+     "indicative_closing_rank": 48247,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 52147
+     "indicative_closing_rank": 52147,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 61063
+     "indicative_closing_rank": 61063,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -10630,37 +11304,43 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 78084
+     "indicative_closing_rank": 78084,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 115892
+     "indicative_closing_rank": 115892,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 170231
+     "indicative_closing_rank": 170231,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 174477
+     "indicative_closing_rank": 174477,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Biosciences and Bioengineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 182602
+     "indicative_closing_rank": 182602,
+     "career_id": "biological-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 201715
+     "indicative_closing_rank": 201715,
+     "career_id": "mechanical-mechatronics-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -10766,37 +11446,43 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 185001
+     "indicative_closing_rank": 185001,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Machine Learning",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 288771
+     "indicative_closing_rank": 288771,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 415454
+     "indicative_closing_rank": 415454,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 514742
+     "indicative_closing_rank": 514742,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 626461
+     "indicative_closing_rank": 626461,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 629625
+     "indicative_closing_rank": 629625,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -10891,55 +11577,64 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 27947
+     "indicative_closing_rank": 27947,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 32619
+     "indicative_closing_rank": 32619,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Telecommunication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 41294
+     "indicative_closing_rank": 41294,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 50882
+     "indicative_closing_rank": 50882,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Instrumentation Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 51031
+     "indicative_closing_rank": 51031,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 55093
+     "indicative_closing_rank": 55093,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 55931
+     "indicative_closing_rank": 55931,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Biomedical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 69348
+     "indicative_closing_rank": 69348,
+     "career_id": "biomedical-engineering"
     },
     {
      "branch": "Industrial and Production Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 71193
+     "indicative_closing_rank": 71193,
+     "career_id": "industrial-manufacturing-production-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -11027,37 +11722,43 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 62096
+     "indicative_closing_rank": 62096,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Agricultural Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 101780
+     "indicative_closing_rank": 101780,
+     "career_id": "agricultural-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": null
+     "indicative_closing_rank": null,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": null
+     "indicative_closing_rank": null,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": null
+     "indicative_closing_rank": null,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": null
+     "indicative_closing_rank": null,
+     "career_id": "mechanical-mechatronics-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -11164,67 +11865,78 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 19069
+     "indicative_closing_rank": 19069,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering with Major in Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 19533
+     "indicative_closing_rank": 19533,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 23187
+     "indicative_closing_rank": 23187,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "B.Tech. in Electronics and Communication Engineering and M.Tech. in Microelectronics and VLSI Systems",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 24892
+     "indicative_closing_rank": 24892,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 25834
+     "indicative_closing_rank": 25834,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "B.Tech. in Electronics and Communication Engineering and M.Tech. in Communication Systems",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 28850
+     "indicative_closing_rank": 28850,
+     "career_id": null
     },
     {
      "branch": "B.Tech in Mechanical Engineering and M.Tech in AI and Robotics",
      "years": 5,
      "degree": "B.Tech. + M.Tech./MS (Dual Degree)",
-     "indicative_closing_rank": 38708
+     "indicative_closing_rank": 38708,
+     "career_id": null
     },
     {
      "branch": "Engineering Physics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 39727
+     "indicative_closing_rank": 39727,
+     "career_id": "engineering-physics"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 44137
+     "indicative_closing_rank": 44137,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Design Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 50908
+     "indicative_closing_rank": 50908,
+     "career_id": "design"
     },
     {
      "branch": "Smart Manufacturing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 51448
+     "indicative_closing_rank": 51448,
+     "career_id": "industrial-manufacturing-production-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -11329,25 +12041,29 @@
      "branch": "Computer Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 47706
+     "indicative_closing_rank": 47706,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 61921
+     "indicative_closing_rank": 61921,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 67544
+     "indicative_closing_rank": 67544,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 83677
+     "indicative_closing_rank": 83677,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -11442,31 +12158,36 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 33833
+     "indicative_closing_rank": 33833,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 39873
+     "indicative_closing_rank": 39873,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 40118
+     "indicative_closing_rank": 40118,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Telecommunication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 45436
+     "indicative_closing_rank": 45436,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 46244
+     "indicative_closing_rank": 46244,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -11562,19 +12283,22 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 98436
+     "indicative_closing_rank": 98436,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 128531
+     "indicative_closing_rank": 128531,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Agricultural Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 246536
+     "indicative_closing_rank": 246536,
+     "career_id": "agricultural-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -11639,25 +12363,29 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 113577
+     "indicative_closing_rank": 113577,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 133575
+     "indicative_closing_rank": 133575,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 144484
+     "indicative_closing_rank": 144484,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 146293
+     "indicative_closing_rank": 146293,
+     "career_id": "mechanical-mechatronics-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -11716,43 +12444,50 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 70211
+     "indicative_closing_rank": 70211,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Machine Learning",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 82815
+     "indicative_closing_rank": 82815,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 87928
+     "indicative_closing_rank": 87928,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 98370
+     "indicative_closing_rank": 98370,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 5,
      "degree": "Integrated Master of Science",
-     "indicative_closing_rank": 99593
+     "indicative_closing_rank": 99593,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 114860
+     "indicative_closing_rank": 114860,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 120505
+     "indicative_closing_rank": 120505,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -11809,25 +12544,29 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 74114
+     "indicative_closing_rank": 74114,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 85150
+     "indicative_closing_rank": 85150,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 91069
+     "indicative_closing_rank": 91069,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 105884
+     "indicative_closing_rank": 105884,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -11891,25 +12630,29 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 64782
+     "indicative_closing_rank": 64782,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 84049
+     "indicative_closing_rank": 84049,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 104045
+     "indicative_closing_rank": 104045,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Printing and Packaging Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 104435
+     "indicative_closing_rank": 104435,
+     "career_id": "printing-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -11973,31 +12716,36 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 81019
+     "indicative_closing_rank": 81019,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering with specialization in Cyber Security",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 83802
+     "indicative_closing_rank": 83802,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 91635
+     "indicative_closing_rank": 91635,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 92490
+     "indicative_closing_rank": 92490,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering (Avionics)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 95952
+     "indicative_closing_rank": 95952,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -12061,19 +12809,22 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 57546
+     "indicative_closing_rank": 57546,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 64451
+     "indicative_closing_rank": 64451,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Bio Medical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 82131
+     "indicative_closing_rank": 82131,
+     "career_id": "biomedical-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -12137,31 +12888,36 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 55464
+     "indicative_closing_rank": 55464,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 70302
+     "indicative_closing_rank": 70302,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Instrumentation Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 78524
+     "indicative_closing_rank": 78524,
+     "career_id": "instrumentation-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 84979
+     "indicative_closing_rank": 84979,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Food Engineering and Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 91799
+     "indicative_closing_rank": 91799,
+     "career_id": "food-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -12226,19 +12982,22 @@
      "branch": "Computer Science Engineering (Data Science)",
      "years": 4,
      "degree": "B. Tech / B. Tech (Hons.)",
-     "indicative_closing_rank": 72826
+     "indicative_closing_rank": 72826,
+     "career_id": null
     },
     {
      "branch": "Computer Science Engineering (Artificial Intelligence)",
      "years": 4,
      "degree": "B. Tech / B. Tech (Hons.)",
-     "indicative_closing_rank": 74493
+     "indicative_closing_rank": 74493,
+     "career_id": null
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 106159
+     "indicative_closing_rank": 106159,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -12302,37 +13061,43 @@
      "branch": "B.Tech in Artificial Intelligenece and Data Science (Transportation and Logistics)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 56763
+     "indicative_closing_rank": 56763,
+     "career_id": null
     },
     {
      "branch": "B.Tech in Electronics & Communication Engineering (Rail Engineering)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 65943
+     "indicative_closing_rank": 65943,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "B.Tech in Aviation Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 67961
+     "indicative_closing_rank": 67961,
+     "career_id": "aerospace-engineering"
     },
     {
      "branch": "B.Tech in Electrical Engineering ( Rail Engineering)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 76385
+     "indicative_closing_rank": 76385,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "B.Tech in Mechanical Engineering ( Rail Engineering)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 78762
+     "indicative_closing_rank": 78762,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "B.Tech in Civil Engineering (Rail Engineering)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 89062
+     "indicative_closing_rank": 89062,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -12397,31 +13162,36 @@
      "branch": "Computer Science Engineering (Artificial lntelligence and Machine Learning)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 147447
+     "indicative_closing_rank": 147447,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 288733
+     "indicative_closing_rank": 288733,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 294449
+     "indicative_closing_rank": 294449,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil and Environmental Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 450734
+     "indicative_closing_rank": 450734,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Food Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 522500
+     "indicative_closing_rank": 522500,
+     "career_id": "food-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -12478,25 +13248,29 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 78706
+     "indicative_closing_rank": 78706,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 85712
+     "indicative_closing_rank": 85712,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 92685
+     "indicative_closing_rank": 92685,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 106206
+     "indicative_closing_rank": 106206,
+     "career_id": "mechanical-mechatronics-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -12560,37 +13334,43 @@
      "branch": "Computer Science and Engineering with specialization in Quantum Technologies",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 57736
+     "indicative_closing_rank": 57736,
+     "career_id": null
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 58080
+     "indicative_closing_rank": 58080,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering with specialization in Artificial Intelligence and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 60321
+     "indicative_closing_rank": 60321,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering with specialization in Cyber Security",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 62831
+     "indicative_closing_rank": 62831,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 65373
+     "indicative_closing_rank": 65373,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering with specialization in VLSI and Embedded Systems",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 69257
+     "indicative_closing_rank": 69257,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -12654,7 +13434,8 @@
      "branch": "Carpet and Textile Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 120668
+     "indicative_closing_rank": 120668,
+     "career_id": "textile-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -12718,7 +13499,8 @@
      "branch": "Handloom and Textile Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 115651
+     "indicative_closing_rank": 115651,
+     "career_id": "textile-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -12775,7 +13557,8 @@
      "branch": "Handloom and Textile Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 112411
+     "indicative_closing_rank": 112411,
+     "career_id": "textile-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -12839,37 +13622,43 @@
      "branch": "Computer Science Engineering (Artificial lntelligence and Machine Learning)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 27752
+     "indicative_closing_rank": 27752,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 29123
+     "indicative_closing_rank": 29123,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science Engineering (Data Science and Analytics)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 30477
+     "indicative_closing_rank": 30477,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science Engineering (Human Computer lnteraction and Gaming Technology)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 33893
+     "indicative_closing_rank": 33893,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering (Internet of Things)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 39245
+     "indicative_closing_rank": 39245,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 40844
+     "indicative_closing_rank": 40844,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -12933,13 +13722,15 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 21029
+     "indicative_closing_rank": 21029,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 27380
+     "indicative_closing_rank": 27380,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -13004,31 +13795,36 @@
      "branch": "Computer Science and Engineering (with Specialization of Data Science and Artificial Intelligence)",
      "years": 4,
      "degree": "B. Tech / B. Tech (Hons.)",
-     "indicative_closing_rank": 36988
+     "indicative_closing_rank": 36988,
+     "career_id": null
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 38063
+     "indicative_closing_rank": 38063,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "B.Tech in Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 41831
+     "indicative_closing_rank": 41831,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering (with Specialization of Embedded Systems and Internet of Things)",
      "years": 4,
      "degree": "B. Tech / B. Tech (Hons.)",
-     "indicative_closing_rank": 44503
+     "indicative_closing_rank": 44503,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 45216
+     "indicative_closing_rank": 45216,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -13092,19 +13888,22 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 26387
+     "indicative_closing_rank": 26387,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 27291
+     "indicative_closing_rank": 27291,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 33596
+     "indicative_closing_rank": 33596,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -13168,19 +13967,22 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 27400
+     "indicative_closing_rank": 27400,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Data Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 30212
+     "indicative_closing_rank": 30212,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 36737
+     "indicative_closing_rank": 36737,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -13244,25 +14046,29 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 44476
+     "indicative_closing_rank": 44476,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 45422
+     "indicative_closing_rank": 45422,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 47785
+     "indicative_closing_rank": 47785,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechatronics and Automation Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 53156
+     "indicative_closing_rank": 53156,
+     "career_id": "mechanical-mechatronics-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -13326,55 +14132,64 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 27095
+     "indicative_closing_rank": 27095,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering (Artificial Intelligence)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 27359
+     "indicative_closing_rank": 27359,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering (Data Science)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 28976
+     "indicative_closing_rank": 28976,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering (Cyber Security)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 31569
+     "indicative_closing_rank": 31569,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "B.Tech in Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 33940
+     "indicative_closing_rank": 33940,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Computer Science and Engineering (Cyber Physical System)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 35838
+     "indicative_closing_rank": 35838,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 36619
+     "indicative_closing_rank": 36619,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 40247
+     "indicative_closing_rank": 40247,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Physics and Computational Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 43349
+     "indicative_closing_rank": 43349,
+     "career_id": "physics"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -13439,43 +14254,50 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 33147
+     "indicative_closing_rank": 33147,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 37040
+     "indicative_closing_rank": 37040,
+     "career_id": null
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 41188
+     "indicative_closing_rank": 41188,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering with specialization in Design and Manufacturing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 44105
+     "indicative_closing_rank": 44105,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 47113
+     "indicative_closing_rank": 47113,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering with specialization in Design and Manufacturing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 52520
+     "indicative_closing_rank": 52520,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 5,
      "degree": "Bachelor and Master of Technology (Dual Degree)",
-     "indicative_closing_rank": 54254
+     "indicative_closing_rank": 54254,
+     "career_id": "mechanical-mechatronics-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -13539,25 +14361,29 @@
      "branch": "Computer Science and Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9562
+     "indicative_closing_rank": 9562,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 9580
+     "indicative_closing_rank": 9580,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Business",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11292
+     "indicative_closing_rank": 11292,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 11416
+     "indicative_closing_rank": 11416,
+     "career_id": "computer-science-information-technology"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -13621,25 +14447,29 @@
      "branch": "Computer Science and Engineering (Artificial Intelligence and Machine Learning)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 26485
+     "indicative_closing_rank": 26485,
+     "career_id": null
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 28707
+     "indicative_closing_rank": 28707,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering (Cyber Security)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 29537
+     "indicative_closing_rank": 29537,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 36049
+     "indicative_closing_rank": 36049,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -13703,25 +14533,29 @@
      "branch": "Computer Science and Engineering ( Artificial Intelligence & Data Science)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 27113
+     "indicative_closing_rank": 27113,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 28335
+     "indicative_closing_rank": 28335,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering (VLSI Design)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 32763
+     "indicative_closing_rank": 32763,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 38827
+     "indicative_closing_rank": 38827,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -13785,19 +14619,22 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 41121
+     "indicative_closing_rank": 41121,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Data Science and Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 43328
+     "indicative_closing_rank": 43328,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 45440
+     "indicative_closing_rank": 45440,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -13861,25 +14698,29 @@
      "branch": "Computer Science and Engineering ( Artificial Intelligence & Data Science)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 37118
+     "indicative_closing_rank": 37118,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 44154
+     "indicative_closing_rank": 44154,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering (Cyber Security)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 44403
+     "indicative_closing_rank": 44403,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 47163
+     "indicative_closing_rank": 47163,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -13943,19 +14784,22 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 32506
+     "indicative_closing_rank": 32506,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "CSE ( Data Science & Analytics)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 35928
+     "indicative_closing_rank": 35928,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 37385
+     "indicative_closing_rank": 37385,
+     "career_id": "computer-science-information-technology"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14019,25 +14863,29 @@
      "branch": "Computer Science and Engineering with specialization in Artificial Intelligence and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 32780
+     "indicative_closing_rank": 32780,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 40217
+     "indicative_closing_rank": 40217,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering with specialization in Cyber Security",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 40718
+     "indicative_closing_rank": 40718,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 41402
+     "indicative_closing_rank": 41402,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14101,25 +14949,29 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 33468
+     "indicative_closing_rank": 33468,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering (Data Science)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 34479
+     "indicative_closing_rank": 34479,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Computer Science and Engineering (Cyber Security)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 35166
+     "indicative_closing_rank": 35166,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 42197
+     "indicative_closing_rank": 42197,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14183,25 +15035,29 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 24840
+     "indicative_closing_rank": 24840,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 28979
+     "indicative_closing_rank": 28979,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 29856
+     "indicative_closing_rank": 29856,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 37951
+     "indicative_closing_rank": 37951,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14265,7 +15121,8 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 44304
+     "indicative_closing_rank": 44304,
+     "career_id": "computer-science-information-technology"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14329,19 +15186,22 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 39231
+     "indicative_closing_rank": 39231,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 42565
+     "indicative_closing_rank": 42565,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 44651
+     "indicative_closing_rank": 44651,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14398,25 +15258,29 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 6242
+     "indicative_closing_rank": 6242,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 7932
+     "indicative_closing_rank": 7932,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 10095
+     "indicative_closing_rank": 10095,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 13451
+     "indicative_closing_rank": 13451,
+     "career_id": "mechanical-mechatronics-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14496,19 +15360,22 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 36760
+     "indicative_closing_rank": 36760,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 41577
+     "indicative_closing_rank": 41577,
+     "career_id": null
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 43476
+     "indicative_closing_rank": 43476,
+     "career_id": "mathematics-and-computing"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14573,7 +15440,8 @@
      "branch": "Chemical Engineering",
      "years": 5,
      "degree": "Integrated Masters in Technology",
-     "indicative_closing_rank": 94719
+     "indicative_closing_rank": 94719,
+     "career_id": "chemical-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14630,37 +15498,43 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 70262
+     "indicative_closing_rank": 70262,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Aeronautical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 85638
+     "indicative_closing_rank": 85638,
+     "career_id": "aerospace-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 87468
+     "indicative_closing_rank": 87468,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Fashion and Apparel Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 122521
+     "indicative_closing_rank": 122521,
+     "career_id": "textile-engineering"
     },
     {
      "branch": "Dairy Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 125047
+     "indicative_closing_rank": 125047,
+     "career_id": "dairy-engineering"
     },
     {
      "branch": "Food Engineering and Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 125271
+     "indicative_closing_rank": 125271,
+     "career_id": "food-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14724,19 +15598,22 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 18851
+     "indicative_closing_rank": 18851,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Data Science and Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 22152
+     "indicative_closing_rank": 22152,
+     "career_id": null
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 30902
+     "indicative_closing_rank": 30902,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14801,7 +15678,8 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 33353
+     "indicative_closing_rank": 33353,
+     "career_id": "architecture"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14874,13 +15752,15 @@
      "branch": "Computer Science and Engineering with Major in Artificial Intelligence",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 49977
+     "indicative_closing_rank": 49977,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 64472
+     "indicative_closing_rank": 64472,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -14960,13 +15840,15 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 31402
+     "indicative_closing_rank": 31402,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 41588
+     "indicative_closing_rank": 41588,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15032,37 +15914,43 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 1258
+     "indicative_closing_rank": 1258,
+     "career_id": "architecture"
     },
     {
      "branch": "Computer Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 75540
+     "indicative_closing_rank": 75540,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 81999
+     "indicative_closing_rank": 81999,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 86262
+     "indicative_closing_rank": 86262,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 89909
+     "indicative_closing_rank": 89909,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 109020
+     "indicative_closing_rank": 109020,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15126,25 +16014,29 @@
      "branch": "Computer Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 56268
+     "indicative_closing_rank": 56268,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 68000
+     "indicative_closing_rank": 68000,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Metallurgy and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 79761
+     "indicative_closing_rank": 79761,
+     "career_id": "metallurgy-engineering-and-material-science"
     },
     {
      "branch": "Production and Industrial Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 85868
+     "indicative_closing_rank": 85868,
+     "career_id": "industrial-manufacturing-production-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15208,7 +16100,8 @@
      "branch": "Computer Science and Engineering (Internet of Things, Cyber Security including Block Chain Technology )",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 60700
+     "indicative_closing_rank": 60700,
+     "career_id": "cyber-security"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15265,13 +16158,15 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 51218
+     "indicative_closing_rank": 51218,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronic Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 61907
+     "indicative_closing_rank": 61907,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15328,13 +16223,15 @@
      "branch": "Computer Science and Engineering with minor in AI and ML",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 65778
+     "indicative_closing_rank": 65778,
+     "career_id": null
     },
     {
      "branch": "B. Tech in Electronics and Communication Engineering with minor in Wearable Electronics",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 72993
+     "indicative_closing_rank": 72993,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15391,7 +16288,8 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 63949
+     "indicative_closing_rank": 63949,
+     "career_id": "computer-science-information-technology"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15448,7 +16346,8 @@
      "branch": "B.Tech in CSE (AI and ML)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 50647
+     "indicative_closing_rank": 50647,
+     "career_id": null
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15505,7 +16404,8 @@
      "branch": "Food Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 104649
+     "indicative_closing_rank": 104649,
+     "career_id": "food-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15570,37 +16470,43 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 39594
+     "indicative_closing_rank": 39594,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 44158
+     "indicative_closing_rank": 44158,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 50145
+     "indicative_closing_rank": 50145,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electronics and Instrumentation Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 53110
+     "indicative_closing_rank": 53110,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 56813
+     "indicative_closing_rank": 56813,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 60689
+     "indicative_closing_rank": 60689,
+     "career_id": "civil-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15681,49 +16587,57 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 18183
+     "indicative_closing_rank": 18183,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 26754
+     "indicative_closing_rank": 26754,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 39438
+     "indicative_closing_rank": 39438,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 44846
+     "indicative_closing_rank": 44846,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 53333
+     "indicative_closing_rank": 53333,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 55070
+     "indicative_closing_rank": 55070,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Bio Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 61356
+     "indicative_closing_rank": 61356,
+     "career_id": "biotechnology"
     },
     {
      "branch": "Metallurgical and Materials Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 61466
+     "indicative_closing_rank": 61466,
+     "career_id": "metallurgy-engineering-and-material-science"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15788,43 +16702,50 @@
      "branch": "Chemical Science and Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 57895
+     "indicative_closing_rank": 57895,
+     "career_id": "chemical-science-and-technology"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 548694
+     "indicative_closing_rank": 548694,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 563566
+     "indicative_closing_rank": 563566,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 718900
+     "indicative_closing_rank": 718900,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mathematics and Computing",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 764291
+     "indicative_closing_rank": 764291,
+     "career_id": "mathematics-and-computing"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1105820
+     "indicative_closing_rank": 1105820,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 1314967
+     "indicative_closing_rank": 1314967,
+     "career_id": "mechanical-mechatronics-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15904,25 +16825,29 @@
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 85700
+     "indicative_closing_rank": 85700,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 89121
+     "indicative_closing_rank": 89121,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Energy Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 92928
+     "indicative_closing_rank": 92928,
+     "career_id": "energy-engineering"
     },
     {
      "branch": "Biomedical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 100180
+     "indicative_closing_rank": 100180,
+     "career_id": "biomedical-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -15987,55 +16912,64 @@
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 47439
+     "indicative_closing_rank": 47439,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Instrumentation Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 58814
+     "indicative_closing_rank": 58814,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Electrical and Electronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 58937
+     "indicative_closing_rank": 58937,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 65703
+     "indicative_closing_rank": 65703,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 209016
+     "indicative_closing_rank": 209016,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 244172
+     "indicative_closing_rank": 244172,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechatronics Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 248412
+     "indicative_closing_rank": 248412,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 386246
+     "indicative_closing_rank": 386246,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 423455
+     "indicative_closing_rank": 423455,
+     "career_id": "mechanical-mechatronics-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -16099,13 +17033,15 @@
      "branch": "Aerospace Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 66956
+     "indicative_closing_rank": 66956,
+     "career_id": "aerospace-engineering"
     },
     {
      "branch": "Electronics and Communication Engineering (Avionics)",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 76802
+     "indicative_closing_rank": 76802,
+     "career_id": "electrical-electronics-communications-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -16164,13 +17100,15 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 474
+     "indicative_closing_rank": 474,
+     "career_id": "architecture"
     },
     {
      "branch": "Planning",
      "years": 4,
      "degree": "Bachelor of Planning",
-     "indicative_closing_rank": 756
+     "indicative_closing_rank": 756,
+     "career_id": "planning"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -16229,13 +17167,15 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 207
+     "indicative_closing_rank": 207,
+     "career_id": "architecture"
     },
     {
      "branch": "Planning",
      "years": 4,
      "degree": "Bachelor of Planning",
-     "indicative_closing_rank": 233
+     "indicative_closing_rank": 233,
+     "career_id": "planning"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -16294,13 +17234,15 @@
      "branch": "Architecture",
      "years": 5,
      "degree": "Bachelor of Architecture",
-     "indicative_closing_rank": 566
+     "indicative_closing_rank": 566,
+     "career_id": "architecture"
     },
     {
      "branch": "Planning",
      "years": 4,
      "degree": "Bachelor of Planning",
-     "indicative_closing_rank": 825
+     "indicative_closing_rank": 825,
+     "career_id": "planning"
     }
    ],
    "source": "JoSAA 2025 Round 6",
@@ -16357,61 +17299,71 @@
      "branch": "Computer Science and Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 75104
+     "indicative_closing_rank": 75104,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Artificial Intelligence and Data Science",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 81910
+     "indicative_closing_rank": 81910,
+     "career_id": null
     },
     {
      "branch": "Information Technology",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 87017
+     "indicative_closing_rank": 87017,
+     "career_id": "computer-science-information-technology"
     },
     {
      "branch": "Electronics and Communication Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 87787
+     "indicative_closing_rank": 87787,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Animation and VFX",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 95386
+     "indicative_closing_rank": 95386,
+     "career_id": "design"
     },
     {
      "branch": "Electrical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 97276
+     "indicative_closing_rank": 97276,
+     "career_id": "electrical-electronics-communications-engineering"
     },
     {
      "branch": "Mechanical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 103475
+     "indicative_closing_rank": 103475,
+     "career_id": "mechanical-mechatronics-engineering"
     },
     {
      "branch": "Chemical Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 109723
+     "indicative_closing_rank": 109723,
+     "career_id": "chemical-engineering"
     },
     {
      "branch": "Civil Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 110442
+     "indicative_closing_rank": 110442,
+     "career_id": "civil-engineering"
     },
     {
      "branch": "Industrial and Production Engineering",
      "years": 4,
      "degree": "Bachelor of Technology",
-     "indicative_closing_rank": 118408
+     "indicative_closing_rank": 118408,
+     "career_id": "industrial-manufacturing-production-engineering"
     }
    ],
    "source": "JoSAA 2025 Round 6",

--- a/scripts/add_fact_tracks_to_predictor.py
+++ b/scripts/add_fact_tracks_to_predictor.py
@@ -25,7 +25,7 @@ from pathlib import Path
 import pandas as pd
 
 REPO = Path(__file__).resolve().parent.parent
-PARQUET = Path("/Users/surya/jan2023/external_data_sources/neet/clean/neet_fact_cutoffs.parquet")
+PARQUET = REPO.parent / Path("external_data_sources/neet/clean/neet_fact_cutoffs.parquet")
 NEETUG = REPO / "public/data/NEETUG/NEETUG.json"
 STATE_CATS = REPO / "public/data/NEETUG/neet_state_categories.json"
 

--- a/scripts/build_apeapcet_2025.py
+++ b/scripts/build_apeapcet_2025.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import pandas as pd
 
 REPO = Path(__file__).resolve().parent.parent
-PARQUET = Path("/Users/surya/jan2023/external_data_sources/apeapcet/clean/apeapcet_fact_cutoffs.parquet")
+PARQUET = REPO.parent / Path("external_data_sources/apeapcet/clean/apeapcet_fact_cutoffs.parquet")
 OUT = REPO / "public/data/APEAPCET/apeapcet_data.json"
 
 CT_LABEL = {"Univ-Govt": "Government University",

--- a/scripts/build_careers_data.py
+++ b/scripts/build_careers_data.py
@@ -17,9 +17,9 @@ import re
 
 import pandas as pd
 
-SRC = "/Users/surya/jan2023/Career_Streams_Engineering_Populated - Sheet1.csv"
-TAXONOMY = "/Users/surya/jan2023/branch - Branch.csv"
-EXAM_MAP = "/Users/surya/jan2023/exam_branch_mapping.csv"
+SRC = "data-sources/career_streams.csv"
+TAXONOMY = "data-sources/branch_taxonomy.csv"
+EXAM_MAP = "data-sources/exam_branch_mapping.csv"
 EXAMS_TAB = "public/data/exams/exams.json"
 OUT_DIR = "public/data/careers"
 

--- a/scripts/build_colleges_data.py
+++ b/scripts/build_colleges_data.py
@@ -64,6 +64,46 @@ def parse_rank(v):
     return int(digits), prep
 
 
+# branch text -> career page: JoSAA branch strings resolve to a parent
+# branch (exam_branch_mapping) and each parent to its career slug
+# (branch_to_career.json, built by build_careers_data.py) — so a branch in
+# a college's programme table can link to "what does this lead to".
+EXAM_BRANCH_MAP = "data-sources/exam_branch_mapping.csv"
+BRANCH_TO_CAREER = "public/data/careers/branch_to_career.json"
+
+
+def career_lookup():
+    import csv
+    b2c = json.load(open(BRANCH_TO_CAREER))
+    base_to_career = {}
+    conflicts = set()
+    with open(EXAM_BRANCH_MAP) as fh:
+        for r in csv.DictReader(fh):
+            if r["exam"] != "JoSAA":
+                continue
+            # strip ONLY the trailing "(4 Years, Bachelor of Technology)" —
+            # a first-paren split collapses "CSE (Cyber Security)" into
+            # plain CSE and links the wrong career
+            base = re.sub(r"\s*\(\d+\s*Years?,[^)]*\)$", "",
+                          r["branch_raw"]).strip()
+            cid = b2c.get(r["branch_id"])
+            if cid:
+                if base in base_to_career and base_to_career[base] != cid:
+                    conflicts.add(base)
+                base_to_career.setdefault(base, cid)
+    # a branch whose NAME is itself a career wins its own page
+    # ("Engineering Physics" -> engineering-physics, not physics)
+    career_ids = set(b2c.values())
+    for base in list(base_to_career):
+        exact = re.sub(r"[^a-z0-9]+", "-", base.lower()).strip("-")
+        if exact in career_ids:
+            base_to_career[base] = exact
+            conflicts.discard(base)
+    for b in sorted(conflicts):
+        print(f"  WARNING: branch base maps to two careers, kept first: {b}")
+    return base_to_career
+
+
 # Public / Private / Government-aided from AISHE's kind + management fields.
 # The few colleges AISHE leaves blank are pinned by name (all verified):
 # BIT Mesra and its off-campuses are a private deemed university; ICT Mumbai
@@ -264,6 +304,7 @@ def build_josaa(client):
 
 
 def main():
+    careers_by_branch = career_lookup()
     ap = argparse.ArgumentParser(description=__doc__)
     ap.add_argument("--dry-run", action="store_true")
     args = ap.parse_args()
@@ -502,7 +543,8 @@ def main():
                         if k not in best or rank > best[k]:
                             best[k] = rank
             lst = [{"branch": b, "years": y, "degree": d,
-                    "indicative_closing_rank": best.get((b, y, d))}
+                    "indicative_closing_rank": best.get((b, y, d)),
+                    "career_id": careers_by_branch.get(b)}
                    for (b, y, d) in branches]
             lst.sort(key=lambda z: (z["indicative_closing_rank"] is None,
                                     z["indicative_closing_rank"] or 0, z["branch"]))

--- a/scripts/build_exams_data.py
+++ b/scripts/build_exams_data.py
@@ -21,7 +21,7 @@ from collections import defaultdict
 
 import pandas as pd
 
-SRC = "/Users/surya/jan2023/exams_cleaned.csv"
+SRC = "data-sources/exams_cleaned.csv"
 OUT = "public/data/exams/exams.json"
 # Hand-formatted paper patterns: the sheet stores sections and question counts
 # as two parallel run-on strings; scripts/pattern_formats.json aligns them into

--- a/scripts/build_keam_2026.py
+++ b/scripts/build_keam_2026.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import pandas as pd
 
 REPO = Path(__file__).resolve().parent.parent
-PARQUET = Path("/Users/surya/jan2023/external_data_sources/keam/clean/keam_fact_cutoffs.parquet")
+PARQUET = REPO.parent / Path("external_data_sources/keam/clean/keam_fact_cutoffs.parquet")
 OUT = REPO / "public/data/KEAM/keam_data.json"
 
 CATS = ["SM", "EZ", "MU", "LA", "DV", "VK", "BH", "BX", "KN", "KU",

--- a/scripts/build_ojee_2025.py
+++ b/scripts/build_ojee_2025.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import pandas as pd
 
 REPO = Path(__file__).resolve().parent.parent
-PARQUET = Path("/Users/surya/jan2023/external_data_sources/ojee/clean/ojee_fact_cutoffs.parquet")
+PARQUET = REPO.parent / Path("external_data_sources/ojee/clean/ojee_fact_cutoffs.parquet")
 OUT = REPO / "public/data/OJEE/ojee_data.json"
 
 df = pd.read_parquet(PARQUET)

--- a/scripts/build_wbjee_2026.py
+++ b/scripts/build_wbjee_2026.py
@@ -16,7 +16,7 @@ from pathlib import Path
 import pandas as pd
 
 REPO = Path(__file__).resolve().parent.parent
-PARQUET = Path("/Users/surya/jan2023/external_data_sources/wbjee/clean/wbjee_fact_cutoffs.parquet")
+PARQUET = REPO.parent / Path("external_data_sources/wbjee/clean/wbjee_fact_cutoffs.parquet")
 OUT = REPO / "public/data/WBJEE/wbjee_data.json"
 
 CT_LABEL = {"Govt": "Government", "Govt-Aided": "Government Aided",

--- a/scripts/refresh_tnea_2025.py
+++ b/scripts/refresh_tnea_2025.py
@@ -32,7 +32,7 @@ from pathlib import Path
 import pandas as pd
 
 REPO = Path(__file__).resolve().parent.parent
-PARQUET = Path("/Users/surya/jan2023/external_data_sources/tnea/clean/tnea_fact_cutoffs.parquet")
+PARQUET = REPO.parent / Path("external_data_sources/tnea/clean/tnea_fact_cutoffs.parquet")
 OUT = REPO / "public/data/TNEA/tnea_data.json"
 
 CATEGORY = {"OC": "General/OC", "BC": "BC", "BCM": "BCM", "MBC": "MBC",


### PR DESCRIPTION
Completes the loop: predictor/exams/careers/colleges all reference each other through the branch taxonomy. Verified in-browser: IIT Madras -> CSE -> lands on the CS/IT career page. Also removes every absolute home path from scripts (data-sources/ + sibling-checkout convention), so builds are reproducible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)